### PR TITLE
[FEATURE] Add Telegram messaging channel

### DIFF
--- a/packages/cli/src/commands/channel-telegram.ts
+++ b/packages/cli/src/commands/channel-telegram.ts
@@ -1,0 +1,493 @@
+/**
+ * CLI Command: agentforge channel:telegram
+ *
+ * Configure and start a Telegram bot that routes messages through
+ * the AgentForge agent execution pipeline.
+ *
+ * Usage:
+ *   agentforge channel:telegram start --agent <id> [--token <bot-token>]
+ *   agentforge channel:telegram configure
+ *   agentforge channel:telegram status
+ */
+
+import { Command } from 'commander';
+import { createClient, safeCall } from '../lib/convex-client.js';
+import { header, success, error, info, dim, warn, details, colors } from '../lib/display.js';
+import fs from 'fs-extra';
+import path from 'node:path';
+import readline from 'node:readline';
+
+function prompt(q: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((r) => rl.question(q, (a) => { rl.close(); r(a.trim()); }));
+}
+
+/**
+ * Read a value from .env files in the current directory.
+ */
+function readEnvValue(key: string): string | undefined {
+  const cwd = process.cwd();
+  const envFiles = ['.env.local', '.env', '.env.production'];
+  for (const envFile of envFiles) {
+    const envPath = path.join(cwd, envFile);
+    if (fs.existsSync(envPath)) {
+      const content = fs.readFileSync(envPath, 'utf-8');
+      const match = content.match(new RegExp(`^${key}=(.+)$`, 'm'));
+      if (match) return match[1].trim().replace(/["']/g, '');
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Write a value to .env.local in the current directory.
+ */
+function writeEnvValue(key: string, value: string, envFile: string = '.env.local'): void {
+  const envPath = path.join(process.cwd(), envFile);
+  let content = '';
+  if (fs.existsSync(envPath)) {
+    content = fs.readFileSync(envPath, 'utf-8');
+  }
+
+  const lines = content.split('\n');
+  const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+  if (idx >= 0) {
+    lines[idx] = `${key}=${value}`;
+  } else {
+    lines.push(`${key}=${value}`);
+  }
+
+  fs.writeFileSync(envPath, lines.join('\n'));
+}
+
+export function registerChannelTelegramCommand(program: Command) {
+  const channel = program
+    .command('channel:telegram')
+    .description('Manage the Telegram messaging channel');
+
+  // ─── Start ─────────────────────────────────────────────────────────
+  channel
+    .command('start')
+    .description('Start the Telegram bot and begin routing messages to an agent')
+    .option('-a, --agent <id>', 'Agent ID to route messages to')
+    .option('-t, --token <token>', 'Telegram Bot Token (overrides .env)')
+    .option('--webhook-url <url>', 'Use webhook mode with this URL')
+    .option('--webhook-secret <secret>', 'Webhook verification secret')
+    .option('--bot-username <username>', 'Bot username for @mention detection')
+    .option('--polling-interval <ms>', 'Polling interval in milliseconds', '1000')
+    .option('--log-level <level>', 'Log level: debug, info, warn, error', 'info')
+    .option('--group-mention-only', 'Only respond to @mentions in groups', true)
+    .action(async (opts) => {
+      header('Telegram Channel');
+
+      // Resolve bot token
+      const botToken = opts.token || readEnvValue('TELEGRAM_BOT_TOKEN') || process.env.TELEGRAM_BOT_TOKEN;
+      if (!botToken) {
+        error('Telegram Bot Token not found.');
+        info('Set it with: agentforge channel:telegram configure');
+        info('Or pass it with: --token <bot-token>');
+        info('Or set TELEGRAM_BOT_TOKEN in your .env.local file');
+        process.exit(1);
+      }
+
+      // Resolve Convex URL
+      const convexUrl = readEnvValue('CONVEX_URL') || process.env.CONVEX_URL;
+      if (!convexUrl) {
+        error('CONVEX_URL not found. Run `npx convex dev` first.');
+        process.exit(1);
+      }
+
+      // Resolve agent ID
+      let agentId = opts.agent;
+      if (!agentId) {
+        // Try to get from env
+        agentId = readEnvValue('AGENTFORGE_AGENT_ID') || process.env.AGENTFORGE_AGENT_ID;
+      }
+
+      if (!agentId) {
+        // List agents and let user pick
+        info('No agent specified. Fetching available agents...');
+        const client = await createClient();
+        const agents = await safeCall(
+          () => client.query('agents:list' as any, {}),
+          'Failed to list agents'
+        );
+
+        if (!agents || (agents as any[]).length === 0) {
+          error('No agents found. Create one first: agentforge agents create');
+          process.exit(1);
+        }
+
+        console.log();
+        (agents as any[]).forEach((a: any, i: number) => {
+          console.log(
+            `  ${colors.cyan}${i + 1}.${colors.reset} ${a.name} ${colors.dim}(${a.id})${colors.reset} — ${a.model}`
+          );
+        });
+        console.log();
+
+        const choice = await prompt('Select agent (number or ID): ');
+        const idx = parseInt(choice) - 1;
+        agentId = idx >= 0 && idx < (agents as any[]).length
+          ? (agents as any[])[idx].id
+          : choice;
+      }
+
+      // Display configuration
+      info(`Agent:    ${agentId}`);
+      info(`Convex:   ${convexUrl}`);
+      info(`Mode:     ${opts.webhookUrl ? 'Webhook' : 'Long-polling'}`);
+      info(`Log:      ${opts.logLevel}`);
+      console.log();
+
+      // Dynamically import the TelegramChannel from core
+      // We use dynamic import because the core package may not be installed
+      // in all environments, and we want to give a helpful error message.
+      let TelegramChannel: any;
+      try {
+        // Use string variable to avoid TS2307 — this is a dynamic import for an optional peer
+        const corePkg = '@agentforge-ai/core/channels/telegram';
+        const mod = await import(/* @vite-ignore */ corePkg);
+        TelegramChannel = mod.TelegramChannel;
+      } catch (importError: any) {
+        // Fallback: try to use the Convex HTTP API directly with a minimal implementation
+        error('Could not import @agentforge-ai/core. Using built-in Telegram runner.');
+        dim(`  Error: ${importError.message}`);
+        console.log();
+
+        // Use the built-in minimal runner
+        await runMinimalTelegramBot({
+          botToken,
+          agentId,
+          convexUrl,
+          logLevel: opts.logLevel,
+          pollingIntervalMs: parseInt(opts.pollingInterval),
+        });
+        return;
+      }
+
+      // Start the Telegram channel
+      try {
+        const channel = new TelegramChannel({
+          botToken,
+          agentId,
+          convexUrl,
+          useWebhook: !!opts.webhookUrl,
+          webhookUrl: opts.webhookUrl,
+          webhookSecret: opts.webhookSecret,
+          botUsername: opts.botUsername,
+          groupMentionOnly: opts.groupMentionOnly,
+          pollingIntervalMs: parseInt(opts.pollingInterval),
+          logLevel: opts.logLevel,
+        });
+
+        await channel.start();
+        success('Telegram bot is running!');
+        dim('  Press Ctrl+C to stop.');
+
+        // Keep the process alive
+        await new Promise(() => {});
+      } catch (startError: any) {
+        error(`Failed to start Telegram bot: ${startError.message}`);
+        process.exit(1);
+      }
+    });
+
+  // ─── Configure ─────────────────────────────────────────────────────
+  channel
+    .command('configure')
+    .description('Configure the Telegram bot token and settings')
+    .action(async () => {
+      header('Configure Telegram Channel');
+
+      const currentToken = readEnvValue('TELEGRAM_BOT_TOKEN');
+      if (currentToken) {
+        const masked = currentToken.slice(0, 6) + '****' + currentToken.slice(-4);
+        info(`Current token: ${masked}`);
+      }
+
+      console.log();
+      info('To get a bot token:');
+      dim('  1. Open Telegram and search for @BotFather');
+      dim('  2. Send /newbot and follow the instructions');
+      dim('  3. Copy the token provided');
+      console.log();
+
+      const token = await prompt('Telegram Bot Token: ');
+      if (!token) {
+        error('Bot token is required.');
+        process.exit(1);
+      }
+
+      // Validate the token by calling getMe
+      info('Validating token...');
+      try {
+        const response = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+        const data = await response.json() as { ok: boolean; result?: { username: string; first_name: string } };
+        if (!data.ok) {
+          error('Invalid bot token. Please check and try again.');
+          process.exit(1);
+        }
+        success(`Bot verified: @${data.result?.username} (${data.result?.first_name})`);
+
+        // Save bot username too
+        if (data.result?.username) {
+          writeEnvValue('TELEGRAM_BOT_USERNAME', data.result.username);
+        }
+      } catch (fetchError: any) {
+        warn(`Could not validate token (network error): ${fetchError.message}`);
+        info('Saving token anyway. You can validate later with: agentforge channel:telegram status');
+      }
+
+      writeEnvValue('TELEGRAM_BOT_TOKEN', token);
+      success('Token saved to .env.local');
+
+      // Ask for default agent
+      console.log();
+      const defaultAgent = await prompt('Default agent ID (optional, press Enter to skip): ');
+      if (defaultAgent) {
+        writeEnvValue('AGENTFORGE_AGENT_ID', defaultAgent);
+        success(`Default agent set to: ${defaultAgent}`);
+      }
+
+      console.log();
+      success('Configuration complete!');
+      info('Start the bot with: agentforge channel:telegram start');
+    });
+
+  // ─── Status ────────────────────────────────────────────────────────
+  channel
+    .command('status')
+    .description('Check the Telegram bot configuration and connectivity')
+    .action(async () => {
+      header('Telegram Channel Status');
+
+      const token = readEnvValue('TELEGRAM_BOT_TOKEN');
+      const agentId = readEnvValue('AGENTFORGE_AGENT_ID');
+      const convexUrl = readEnvValue('CONVEX_URL');
+      const botUsername = readEnvValue('TELEGRAM_BOT_USERNAME');
+
+      const statusData: Record<string, string> = {
+        'Bot Token': token ? `${token.slice(0, 6)}****${token.slice(-4)}` : `${colors.red}Not configured${colors.reset}`,
+        'Bot Username': botUsername ? `@${botUsername}` : `${colors.dim}Unknown${colors.reset}`,
+        'Default Agent': agentId || `${colors.dim}Not set${colors.reset}`,
+        'Convex URL': convexUrl || `${colors.red}Not configured${colors.reset}`,
+      };
+
+      details(statusData);
+
+      // Validate token if present
+      if (token) {
+        info('Checking bot connectivity...');
+        try {
+          const response = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+          const data = await response.json() as { ok: boolean; result?: { username: string; first_name: string; id: number } };
+          if (data.ok) {
+            success(`Bot online: @${data.result?.username} (ID: ${data.result?.id})`);
+          } else {
+            error('Bot token is invalid or expired.');
+          }
+        } catch {
+          warn('Could not reach Telegram API (network error).');
+        }
+      }
+
+      // Check Convex connectivity
+      if (convexUrl) {
+        info('Checking Convex connectivity...');
+        try {
+          const client = await createClient();
+          const agents = await client.query('agents:list' as any, {});
+          success(`Convex connected. ${(agents as any[]).length} agents available.`);
+        } catch {
+          warn('Could not reach Convex deployment.');
+        }
+      }
+    });
+}
+
+// =====================================================
+// Minimal Built-in Telegram Bot Runner
+// =====================================================
+
+/**
+ * A minimal Telegram bot runner that works without the @agentforge-ai/core
+ * package. Uses the Telegram Bot API and Convex HTTP API directly.
+ *
+ * This is a fallback for when the core package isn't available
+ * (e.g., in a fresh project before building).
+ */
+async function runMinimalTelegramBot(config: {
+  botToken: string;
+  agentId: string;
+  convexUrl: string;
+  logLevel?: string;
+  pollingIntervalMs?: number;
+}): Promise<void> {
+  const { botToken, agentId, convexUrl } = config;
+  const apiBase = `https://api.telegram.org/bot${botToken}`;
+  const convexBase = convexUrl.replace(/\/$/, '');
+  const threadMap = new Map<string, string>();
+  let lastUpdateId = 0;
+
+  // Verify bot
+  info('Verifying bot token...');
+  const meRes = await fetch(`${apiBase}/getMe`);
+  const meData = await meRes.json() as { ok: boolean; result?: { username: string } };
+  if (!meData.ok) {
+    error('Invalid bot token.');
+    process.exit(1);
+  }
+  success(`Bot connected: @${meData.result?.username}`);
+
+  // Delete any existing webhook
+  await fetch(`${apiBase}/deleteWebhook`, { method: 'POST' });
+
+  info('Polling for messages...');
+  dim('  Press Ctrl+C to stop.');
+  console.log();
+
+  // Graceful shutdown
+  process.on('SIGINT', () => {
+    console.log('\nStopping...');
+    process.exit(0);
+  });
+
+  // Convex HTTP helpers
+  async function convexMutation(fn: string, args: Record<string, unknown>): Promise<unknown> {
+    const res = await fetch(`${convexBase}/api/mutation`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: fn, args }),
+    });
+    const data = await res.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') throw new Error(data.errorMessage);
+    return data.value;
+  }
+
+  async function convexAction(fn: string, args: Record<string, unknown>): Promise<unknown> {
+    const res = await fetch(`${convexBase}/api/action`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: fn, args }),
+    });
+    const data = await res.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') throw new Error(data.errorMessage);
+    return data.value;
+  }
+
+  async function sendTelegramMessage(chatId: string, text: string): Promise<void> {
+    await fetch(`${apiBase}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text }),
+    });
+  }
+
+  async function sendTyping(chatId: string): Promise<void> {
+    await fetch(`${apiBase}/sendChatAction`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, action: 'typing' }),
+    }).catch(() => {});
+  }
+
+  async function getOrCreateThread(chatId: string, senderName?: string): Promise<string> {
+    const cached = threadMap.get(chatId);
+    if (cached) return cached;
+
+    const threadId = await convexMutation('chat:createThread', {
+      agentId,
+      name: senderName ? `Telegram: ${senderName}` : `Telegram Chat ${chatId}`,
+      userId: `telegram:${chatId}`,
+    }) as string;
+
+    threadMap.set(chatId, threadId);
+    return threadId;
+  }
+
+  // Poll loop
+  while (true) {
+    try {
+      const res = await fetch(`${apiBase}/getUpdates`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          offset: lastUpdateId + 1,
+          timeout: 30,
+          allowed_updates: ['message'],
+        }),
+      });
+
+      const data = await res.json() as { ok: boolean; result?: any[] };
+      if (!data.ok || !data.result) continue;
+
+      for (const update of data.result) {
+        lastUpdateId = update.update_id;
+        const msg = update.message;
+        if (!msg?.text) continue;
+
+        const chatId = String(msg.chat.id);
+        const senderName = msg.from?.first_name || 'User';
+        const text = msg.text.trim();
+
+        // Handle commands
+        if (text === '/start') {
+          threadMap.delete(chatId);
+          await sendTelegramMessage(chatId, `👋 Welcome! I'm powered by AgentForge.\n\nSend me a message and I'll respond using AI.\n\nCommands:\n/new — Start a new conversation\n/help — Show help`);
+          continue;
+        }
+        if (text === '/new') {
+          threadMap.delete(chatId);
+          await sendTelegramMessage(chatId, '🔄 New conversation started. Send me a message!');
+          continue;
+        }
+        if (text === '/help') {
+          await sendTelegramMessage(chatId, '🤖 AgentForge Telegram Bot\n\nJust send me a message and I\'ll respond using AI.\n\nCommands:\n/start — Reset and show welcome\n/new — Start a fresh conversation\n/help — Show this help');
+          continue;
+        }
+
+        // Route to agent
+        console.log(`[${senderName}] ${text}`);
+        await sendTyping(chatId);
+
+        try {
+          const threadId = await getOrCreateThread(chatId, senderName);
+          const result = await convexAction('chat:sendMessage', {
+            agentId,
+            threadId,
+            content: text,
+            userId: `telegram:${msg.from?.id || chatId}`,
+          }) as { response: string };
+
+          if (result?.response) {
+            // Split long messages
+            const response = result.response;
+            if (response.length <= 4096) {
+              await sendTelegramMessage(chatId, response);
+            } else {
+              const chunks = response.match(/.{1,4096}/gs) || [];
+              for (const chunk of chunks) {
+                await sendTelegramMessage(chatId, chunk);
+              }
+            }
+            console.log(`[Agent] ${response.substring(0, 100)}${response.length > 100 ? '...' : ''}`);
+          } else {
+            await sendTelegramMessage(chatId, '🤔 I couldn\'t generate a response. Please try again.');
+          }
+        } catch (routeError: any) {
+          console.error(`Error: ${routeError.message}`);
+          await sendTelegramMessage(chatId, '⚠️ Sorry, I encountered an error. Please try again.');
+        }
+      }
+    } catch (pollError: any) {
+      if (pollError.message?.includes('ECONNREFUSED') || pollError.message?.includes('fetch failed')) {
+        warn('Network error. Retrying in 5s...');
+        await new Promise((r) => setTimeout(r, 5000));
+      } else {
+        console.error(`Poll error: ${pollError.message}`);
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { registerVaultCommand } from './commands/vault.js';
 import { registerKeysCommand } from './commands/keys.js';
 import { registerStatusCommand } from './commands/status.js';
 import { registerLoginCommand } from './commands/login.js';
+import { registerChannelTelegramCommand } from './commands/channel-telegram.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -106,6 +107,9 @@ registerVaultCommand(program);
 
 // ─── AI Provider Keys ────────────────────────────────────────────
 registerKeysCommand(program);
+
+// ─── Channels ───────────────────────────────────────────────────
+registerChannelTelegramCommand(program);
 
 // ─── Status, Dashboard, Logs, Heartbeat ──────────────────────────
 registerStatusCommand(program);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,10 @@
     "./workspace": {
       "types": "./dist/workspace.d.ts",
       "import": "./dist/workspace.js"
+    },
+    "./channels/telegram": {
+      "types": "./dist/channels/telegram.d.ts",
+      "import": "./dist/channels/telegram.js"
     }
   },
   "files": [
@@ -60,7 +64,9 @@
     "e2b",
     "sandbox",
     "workspace",
-    "multi-agent"
+    "multi-agent",
+    "telegram",
+    "channels"
   ],
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/src/channels/telegram.test.ts
+++ b/packages/core/src/channels/telegram.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for Telegram Channel Runner.
+ *
+ * Tests the TelegramChannel class that bridges the TelegramAdapter
+ * with the Convex chat pipeline.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TelegramChannel, startTelegramChannel } from './telegram.js';
+import type { TelegramChannelConfig } from './telegram.js';
+
+// =====================================================
+// Test Helpers
+// =====================================================
+
+function createTestConfig(overrides: Partial<TelegramChannelConfig> = {}): TelegramChannelConfig {
+  return {
+    botToken: 'test-bot-token-123',
+    agentId: 'test-agent-1',
+    convexUrl: 'https://test-deployment.convex.cloud',
+    logLevel: 'error', // Suppress logs in tests
+    ...overrides,
+  };
+}
+
+// =====================================================
+// Tests
+// =====================================================
+
+describe('TelegramChannel', () => {
+  describe('constructor', () => {
+    it('should create a TelegramChannel instance', () => {
+      const channel = new TelegramChannel(createTestConfig());
+      expect(channel).toBeInstanceOf(TelegramChannel);
+      expect(channel.running).toBe(false);
+    });
+
+    it('should initialize with empty thread map', () => {
+      const channel = new TelegramChannel(createTestConfig());
+      expect(channel.getThreadMap().size).toBe(0);
+    });
+
+    it('should expose the underlying adapter', () => {
+      const channel = new TelegramChannel(createTestConfig());
+      expect(channel.getAdapter()).toBeDefined();
+      expect(channel.getAdapter().platform).toBe('telegram');
+    });
+  });
+
+  describe('stop', () => {
+    it('should be safe to call stop when not running', async () => {
+      const channel = new TelegramChannel(createTestConfig());
+      await expect(channel.stop()).resolves.not.toThrow();
+    });
+  });
+
+  describe('message splitting', () => {
+    it('should not split short messages', () => {
+      const channel = new TelegramChannel(createTestConfig());
+      // Access private method via any cast for testing
+      const splitMessage = (channel as any).splitMessage.bind(channel);
+      const result = splitMessage('Hello, world!', 4096);
+      expect(result).toEqual(['Hello, world!']);
+    });
+
+    it('should split messages exceeding max length', () => {
+      const channel = new TelegramChannel(createTestConfig());
+      const splitMessage = (channel as any).splitMessage.bind(channel);
+      const longText = 'A'.repeat(5000);
+      const result = splitMessage(longText, 4096);
+      expect(result.length).toBeGreaterThan(1);
+      // All chunks should be within limit
+      for (const chunk of result) {
+        expect(chunk.length).toBeLessThanOrEqual(4096);
+      }
+    });
+
+    it('should prefer splitting at paragraph breaks', () => {
+      const channel = new TelegramChannel(createTestConfig());
+      const splitMessage = (channel as any).splitMessage.bind(channel);
+      const text = 'A'.repeat(2000) + '\n\n' + 'B'.repeat(2000) + '\n\n' + 'C'.repeat(2000);
+      const result = splitMessage(text, 4096);
+      expect(result.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should handle text with no natural break points', () => {
+      const channel = new TelegramChannel(createTestConfig());
+      const splitMessage = (channel as any).splitMessage.bind(channel);
+      const text = 'X'.repeat(10000); // No spaces or newlines
+      const result = splitMessage(text, 4096);
+      expect(result.length).toBe(3); // ceil(10000/4096) = 3
+      for (const chunk of result) {
+        expect(chunk.length).toBeLessThanOrEqual(4096);
+      }
+    });
+  });
+});
+
+describe('startTelegramChannel', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should throw if botToken is missing', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    await expect(
+      startTelegramChannel({ agentId: 'test', convexUrl: 'https://test.convex.cloud' })
+    ).rejects.toThrow('TELEGRAM_BOT_TOKEN is required');
+  });
+
+  it('should throw if convexUrl is missing', async () => {
+    delete process.env.CONVEX_URL;
+    await expect(
+      startTelegramChannel({ botToken: 'test-token', agentId: 'test' })
+    ).rejects.toThrow('CONVEX_URL is required');
+  });
+
+  it('should throw if agentId is missing', async () => {
+    delete process.env.AGENTFORGE_AGENT_ID;
+    await expect(
+      startTelegramChannel({ botToken: 'test-token', convexUrl: 'https://test.convex.cloud' })
+    ).rejects.toThrow('Agent ID is required');
+  });
+});

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -1,0 +1,672 @@
+/**
+ * Telegram Channel for AgentForge.
+ *
+ * Bridges the TelegramAdapter with the AgentForge Convex chat pipeline.
+ * This module:
+ * - Starts the Telegram bot (long-polling or webhook)
+ * - Routes incoming messages through the agent execution pipeline
+ * - Creates/reuses Convex threads per Telegram chat
+ * - Stores all messages in the Convex messages table
+ * - Sends agent responses back to the Telegram user
+ *
+ * @packageDocumentation
+ */
+
+import { TelegramAdapter } from '../adapters/telegram-adapter.js';
+import type {
+  ChannelConfig,
+  InboundMessage,
+  ChannelEvent,
+} from '../channel-adapter.js';
+
+// =====================================================
+// Types
+// =====================================================
+
+/**
+ * Configuration for the Telegram channel runner.
+ */
+export interface TelegramChannelConfig {
+  /** Telegram Bot Token from BotFather */
+  botToken: string;
+  /** Agent ID to route messages to */
+  agentId: string;
+  /** Convex deployment URL */
+  convexUrl: string;
+  /** Whether to use webhook mode (default: false = long-polling) */
+  useWebhook?: boolean;
+  /** Webhook URL (required if useWebhook is true) */
+  webhookUrl?: string;
+  /** Webhook secret for verification */
+  webhookSecret?: string;
+  /** Bot username for @mention detection in groups */
+  botUsername?: string;
+  /** Whether to respond only to @mentions in groups (default: true) */
+  groupMentionOnly?: boolean;
+  /** Polling interval in ms (default: 1000) */
+  pollingIntervalMs?: number;
+  /** User ID for Convex operations (default: 'telegram') */
+  userId?: string;
+  /** Log level: 'debug' | 'info' | 'warn' | 'error' (default: 'info') */
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
+}
+
+/**
+ * Thread mapping: Telegram chatId → Convex threadId.
+ * Persisted in memory for the lifetime of the bot process.
+ */
+type ThreadMap = Map<string, string>;
+
+/**
+ * Logger interface for the channel runner.
+ */
+interface Logger {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+// =====================================================
+// Logger
+// =====================================================
+
+const LOG_LEVELS: Record<string, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function createLogger(level: string = 'info'): Logger {
+  const threshold = LOG_LEVELS[level] ?? 1;
+  const prefix = '[agentforge:telegram]';
+
+  return {
+    debug: (...args: unknown[]) => {
+      if (threshold <= 0) console.log(`${prefix} [DEBUG]`, ...args);
+    },
+    info: (...args: unknown[]) => {
+      if (threshold <= 1) console.log(`${prefix}`, ...args);
+    },
+    warn: (...args: unknown[]) => {
+      if (threshold <= 2) console.warn(`${prefix} [WARN]`, ...args);
+    },
+    error: (...args: unknown[]) => {
+      if (threshold <= 3) console.error(`${prefix} [ERROR]`, ...args);
+    },
+  };
+}
+
+// =====================================================
+// Convex HTTP Client Wrapper
+// =====================================================
+
+/**
+ * Minimal Convex HTTP client for calling queries, mutations, and actions.
+ * Uses the Convex HTTP API directly to avoid requiring the full Convex client
+ * as a dependency in the core package.
+ */
+class ConvexHttpApi {
+  private baseUrl: string;
+
+  constructor(deploymentUrl: string) {
+    // Convert deployment URL to HTTP API URL
+    // e.g., https://hip-cardinal-943.convex.cloud → same
+    this.baseUrl = deploymentUrl.replace(/\/$/, '');
+  }
+
+  /**
+   * Call a Convex query function.
+   */
+  async query(functionPath: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const url = `${this.baseUrl}/api/query`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: functionPath, args }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Convex query ${functionPath} failed: ${response.status} ${text}`);
+    }
+
+    const data = await response.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') {
+      throw new Error(`Convex query ${functionPath} error: ${data.errorMessage}`);
+    }
+    return data.value;
+  }
+
+  /**
+   * Call a Convex mutation function.
+   */
+  async mutation(functionPath: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const url = `${this.baseUrl}/api/mutation`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: functionPath, args }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Convex mutation ${functionPath} failed: ${response.status} ${text}`);
+    }
+
+    const data = await response.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') {
+      throw new Error(`Convex mutation ${functionPath} error: ${data.errorMessage}`);
+    }
+    return data.value;
+  }
+
+  /**
+   * Call a Convex action function.
+   */
+  async action(functionPath: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const url = `${this.baseUrl}/api/action`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: functionPath, args }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Convex action ${functionPath} failed: ${response.status} ${text}`);
+    }
+
+    const data = await response.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') {
+      throw new Error(`Convex action ${functionPath} error: ${data.errorMessage}`);
+    }
+    return data.value;
+  }
+}
+
+// =====================================================
+// Telegram Channel Runner
+// =====================================================
+
+/**
+ * Runs a Telegram bot that routes messages through the AgentForge
+ * Convex chat pipeline.
+ *
+ * @example
+ * ```typescript
+ * import { TelegramChannel } from '@agentforge-ai/core/channels/telegram';
+ *
+ * const channel = new TelegramChannel({
+ *   botToken: process.env.TELEGRAM_BOT_TOKEN!,
+ *   agentId: 'my-agent',
+ *   convexUrl: process.env.CONVEX_URL!,
+ * });
+ *
+ * await channel.start();
+ * ```
+ */
+export class TelegramChannel {
+  private adapter: TelegramAdapter;
+  private convex: ConvexHttpApi;
+  private config: TelegramChannelConfig;
+  private threadMap: ThreadMap = new Map();
+  private logger: Logger;
+  private processingMessages: Set<string> = new Set();
+  private isRunning: boolean = false;
+
+  constructor(config: TelegramChannelConfig) {
+    this.config = config;
+    this.adapter = new TelegramAdapter();
+    this.convex = new ConvexHttpApi(config.convexUrl);
+    this.logger = createLogger(config.logLevel);
+  }
+
+  /**
+   * Start the Telegram channel bot.
+   * Connects to Telegram and begins listening for messages.
+   */
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn('Telegram channel is already running');
+      return;
+    }
+
+    this.logger.info('Starting Telegram channel...');
+    this.logger.info(`Agent ID: ${this.config.agentId}`);
+    this.logger.info(`Convex URL: ${this.config.convexUrl}`);
+
+    // Verify the agent exists in Convex
+    try {
+      const agent = await this.convex.query('agents:get', { id: this.config.agentId });
+      if (!agent) {
+        throw new Error(
+          `Agent "${this.config.agentId}" not found in Convex. ` +
+          `Create it first with: agentforge agents create`
+        );
+      }
+      const agentData = agent as { name: string; model: string; provider: string };
+      this.logger.info(`Agent: ${agentData.name} (${agentData.model} via ${agentData.provider})`);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        throw error;
+      }
+      this.logger.warn('Could not verify agent (Convex may be unreachable). Continuing...');
+    }
+
+    // Wire up message handler
+    this.adapter.on(this.handleEvent.bind(this));
+
+    // Build the ChannelConfig for the adapter
+    const channelConfig: ChannelConfig = {
+      id: `telegram-${this.config.agentId}`,
+      platform: 'telegram',
+      orgId: 'default',
+      agentId: this.config.agentId,
+      enabled: true,
+      credentials: {
+        botToken: this.config.botToken,
+      },
+      settings: {
+        botUsername: this.config.botUsername,
+        groupMentionOnly: this.config.groupMentionOnly ?? true,
+        pollingIntervalMs: this.config.pollingIntervalMs ?? 1000,
+        useWebhook: this.config.useWebhook ?? false,
+        webhookUrl: this.config.webhookUrl,
+        webhookSecret: this.config.webhookSecret,
+      },
+      autoReconnect: true,
+      reconnectIntervalMs: 5000,
+      maxReconnectAttempts: 20,
+    };
+
+    // Start the adapter
+    await this.adapter.start(channelConfig);
+    this.isRunning = true;
+
+    this.logger.info('Telegram channel started successfully!');
+    this.logger.info('Bot is listening for messages...');
+    this.logger.info('Press Ctrl+C to stop.');
+  }
+
+  /**
+   * Stop the Telegram channel bot.
+   */
+  async stop(): Promise<void> {
+    if (!this.isRunning) return;
+
+    this.logger.info('Stopping Telegram channel...');
+    await this.adapter.stop();
+    this.isRunning = false;
+    this.threadMap.clear();
+    this.processingMessages.clear();
+    this.logger.info('Telegram channel stopped.');
+  }
+
+  /**
+   * Get the current thread map (for debugging).
+   */
+  getThreadMap(): ReadonlyMap<string, string> {
+    return this.threadMap;
+  }
+
+  /**
+   * Get the underlying TelegramAdapter instance.
+   */
+  getAdapter(): TelegramAdapter {
+    return this.adapter;
+  }
+
+  /**
+   * Check if the channel is running.
+   */
+  get running(): boolean {
+    return this.isRunning;
+  }
+
+  // ----- Internal: Event Handling -----
+
+  private async handleEvent(event: ChannelEvent): Promise<void> {
+    switch (event.type) {
+      case 'message':
+        await this.handleInboundMessage(event.data as InboundMessage);
+        break;
+
+      case 'connection_state':
+        this.logger.debug('Connection state:', (event.data as { state: string }).state);
+        break;
+
+      case 'error':
+        this.logger.error('Adapter error:', (event.data as { error: Error }).error.message);
+        break;
+
+      default:
+        this.logger.debug('Unhandled event type:', event.type);
+    }
+  }
+
+  private async handleInboundMessage(message: InboundMessage): Promise<void> {
+    // Skip empty messages
+    if (!message.text?.trim()) {
+      this.logger.debug('Skipping empty message');
+      return;
+    }
+
+    // Dedup: prevent processing the same message twice
+    const dedupKey = `${message.chatId}:${message.platformMessageId}`;
+    if (this.processingMessages.has(dedupKey)) {
+      this.logger.debug('Skipping duplicate message:', dedupKey);
+      return;
+    }
+    this.processingMessages.add(dedupKey);
+
+    const senderName = message.sender.displayName || message.sender.username || 'Unknown';
+    this.logger.info(`Message from ${senderName} (chat ${message.chatId}): ${message.text}`);
+
+    try {
+      // Handle /start command
+      if (message.text.startsWith('/start')) {
+        await this.handleStartCommand(message);
+        return;
+      }
+
+      // Handle /new command — create a new thread
+      if (message.text.startsWith('/new')) {
+        this.threadMap.delete(message.chatId);
+        await this.adapter.sendMessage({
+          chatId: message.chatId,
+          text: '🔄 New conversation started. Send me a message!',
+        });
+        return;
+      }
+
+      // Handle /help command
+      if (message.text.startsWith('/help')) {
+        await this.handleHelpCommand(message);
+        return;
+      }
+
+      // Route through the agent execution pipeline
+      await this.routeToAgent(message);
+    } catch (error) {
+      this.logger.error('Error handling message:', error);
+      try {
+        await this.adapter.sendMessage({
+          chatId: message.chatId,
+          text: '⚠️ Sorry, I encountered an error processing your message. Please try again.',
+        });
+      } catch {
+        this.logger.error('Failed to send error message to user');
+      }
+    } finally {
+      // Clean up dedup key after a delay
+      setTimeout(() => {
+        this.processingMessages.delete(dedupKey);
+      }, 30000);
+    }
+  }
+
+  // ----- Internal: Agent Routing -----
+
+  /**
+   * Route a message through the AgentForge chat pipeline:
+   * 1. Get or create a Convex thread for this Telegram chat
+   * 2. Call chat.sendMessage action (stores user msg, calls LLM, stores response)
+   * 3. Send the agent response back to Telegram
+   */
+  private async routeToAgent(message: InboundMessage): Promise<void> {
+    // Show typing indicator while processing
+    await this.adapter.sendTypingIndicator(message.chatId);
+
+    // Get or create thread for this chat
+    const threadId = await this.getOrCreateThread(message.chatId, message.sender.displayName);
+
+    // Call the Convex chat.sendMessage action
+    // This handles: store user msg → call LLM → store assistant msg → record usage
+    const userId = this.config.userId || `telegram:${message.sender.platformUserId}`;
+
+    this.logger.debug(`Sending to agent ${this.config.agentId}, thread ${threadId}`);
+
+    const result = await this.convex.action('chat:sendMessage', {
+      agentId: this.config.agentId,
+      threadId,
+      content: message.text!,
+      userId,
+    }) as { success: boolean; response: string; usage?: { totalTokens: number } };
+
+    if (result?.response) {
+      // Split long messages for Telegram's 4096 char limit
+      const chunks = this.splitMessage(result.response, 4096);
+      for (const chunk of chunks) {
+        await this.adapter.sendMessage({
+          chatId: message.chatId,
+          text: chunk,
+          replyToMessageId: chunks.length === 1 ? message.platformMessageId : undefined,
+        });
+      }
+
+      if (result.usage) {
+        this.logger.debug(`Tokens used: ${result.usage.totalTokens}`);
+      }
+    } else {
+      await this.adapter.sendMessage({
+        chatId: message.chatId,
+        text: '🤔 I received your message but couldn\'t generate a response. Please try again.',
+      });
+    }
+  }
+
+  // ----- Internal: Thread Management -----
+
+  /**
+   * Get or create a Convex thread for a Telegram chat.
+   * Threads are cached in memory and created lazily.
+   */
+  private async getOrCreateThread(chatId: string, senderName?: string): Promise<string> {
+    // Check in-memory cache first
+    const cached = this.threadMap.get(chatId);
+    if (cached) return cached;
+
+    // Create a new thread in Convex
+    const threadName = senderName
+      ? `Telegram: ${senderName}`
+      : `Telegram Chat ${chatId}`;
+
+    const userId = this.config.userId || `telegram:${chatId}`;
+
+    const threadId = await this.convex.mutation('chat:createThread', {
+      agentId: this.config.agentId,
+      name: threadName,
+      userId,
+    }) as string;
+
+    this.threadMap.set(chatId, threadId);
+    this.logger.info(`Created new thread ${threadId} for chat ${chatId}`);
+
+    // Log the channel connection
+    try {
+      await this.convex.mutation('logs:add', {
+        level: 'info',
+        source: 'telegram',
+        message: `New Telegram conversation started by ${senderName || chatId}`,
+        metadata: { chatId, threadId, agentId: this.config.agentId },
+        userId,
+      });
+    } catch {
+      // Non-critical, ignore
+    }
+
+    return threadId;
+  }
+
+  // ----- Internal: Command Handlers -----
+
+  private async handleStartCommand(message: InboundMessage): Promise<void> {
+    // Reset thread for this chat
+    this.threadMap.delete(message.chatId);
+
+    let agentName = 'AI Assistant';
+    try {
+      const agent = await this.convex.query('agents:get', { id: this.config.agentId });
+      if (agent) {
+        agentName = (agent as { name: string }).name;
+      }
+    } catch {
+      // Use default name
+    }
+
+    await this.adapter.sendMessage({
+      chatId: message.chatId,
+      text:
+        `👋 Welcome! I'm *${agentName}*, powered by AgentForge.\n\n` +
+        `Send me a message and I'll respond using AI.\n\n` +
+        `Commands:\n` +
+        `/new — Start a new conversation\n` +
+        `/help — Show help information`,
+      markdown: true,
+      platformOptions: {
+        parse_mode: 'Markdown',
+      },
+    });
+  }
+
+  private async handleHelpCommand(message: InboundMessage): Promise<void> {
+    await this.adapter.sendMessage({
+      chatId: message.chatId,
+      text:
+        `🤖 *AgentForge Telegram Bot*\n\n` +
+        `Just send me a message and I'll respond using AI.\n\n` +
+        `*Commands:*\n` +
+        `/start — Reset and show welcome message\n` +
+        `/new — Start a fresh conversation thread\n` +
+        `/help — Show this help message\n\n` +
+        `_Powered by AgentForge — agentforge.dev_`,
+      markdown: true,
+      platformOptions: {
+        parse_mode: 'Markdown',
+      },
+    });
+  }
+
+  // ----- Internal: Utilities -----
+
+  /**
+   * Split a long message into chunks that fit Telegram's character limit.
+   */
+  private splitMessage(text: string, maxLength: number): string[] {
+    if (text.length <= maxLength) return [text];
+
+    const chunks: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > 0) {
+      if (remaining.length <= maxLength) {
+        chunks.push(remaining);
+        break;
+      }
+
+      // Try to split at a paragraph break
+      let splitIdx = remaining.lastIndexOf('\n\n', maxLength);
+      if (splitIdx === -1 || splitIdx < maxLength / 2) {
+        // Try to split at a line break
+        splitIdx = remaining.lastIndexOf('\n', maxLength);
+      }
+      if (splitIdx === -1 || splitIdx < maxLength / 2) {
+        // Try to split at a space
+        splitIdx = remaining.lastIndexOf(' ', maxLength);
+      }
+      if (splitIdx === -1 || splitIdx < maxLength / 2) {
+        // Hard split
+        splitIdx = maxLength;
+      }
+
+      chunks.push(remaining.substring(0, splitIdx));
+      remaining = remaining.substring(splitIdx).trimStart();
+    }
+
+    return chunks;
+  }
+}
+
+// =====================================================
+// Convenience Factory
+// =====================================================
+
+/**
+ * Create and start a Telegram channel from environment variables.
+ *
+ * Required env vars:
+ * - TELEGRAM_BOT_TOKEN
+ * - CONVEX_URL
+ *
+ * Optional env vars:
+ * - AGENTFORGE_AGENT_ID (default: first active agent)
+ * - TELEGRAM_WEBHOOK_URL
+ * - TELEGRAM_WEBHOOK_SECRET
+ * - TELEGRAM_BOT_USERNAME
+ *
+ * @example
+ * ```typescript
+ * import { startTelegramChannel } from '@agentforge-ai/core/channels/telegram';
+ *
+ * await startTelegramChannel({
+ *   agentId: 'my-agent',
+ * });
+ * ```
+ */
+export async function startTelegramChannel(
+  overrides: Partial<TelegramChannelConfig> = {}
+): Promise<TelegramChannel> {
+  const botToken = overrides.botToken || process.env.TELEGRAM_BOT_TOKEN;
+  const convexUrl = overrides.convexUrl || process.env.CONVEX_URL;
+  const agentId = overrides.agentId || process.env.AGENTFORGE_AGENT_ID;
+
+  if (!botToken) {
+    throw new Error(
+      'TELEGRAM_BOT_TOKEN is required. ' +
+      'Set it in your .env file or pass it as botToken in the config.'
+    );
+  }
+
+  if (!convexUrl) {
+    throw new Error(
+      'CONVEX_URL is required. ' +
+      'Set it in your .env file or pass it as convexUrl in the config.'
+    );
+  }
+
+  if (!agentId) {
+    throw new Error(
+      'Agent ID is required. ' +
+      'Pass it as agentId in the config or set AGENTFORGE_AGENT_ID env var.'
+    );
+  }
+
+  const channel = new TelegramChannel({
+    botToken,
+    convexUrl,
+    agentId,
+    useWebhook: overrides.useWebhook ?? !!process.env.TELEGRAM_WEBHOOK_URL,
+    webhookUrl: overrides.webhookUrl || process.env.TELEGRAM_WEBHOOK_URL,
+    webhookSecret: overrides.webhookSecret || process.env.TELEGRAM_WEBHOOK_SECRET,
+    botUsername: overrides.botUsername || process.env.TELEGRAM_BOT_USERNAME,
+    groupMentionOnly: overrides.groupMentionOnly,
+    pollingIntervalMs: overrides.pollingIntervalMs,
+    userId: overrides.userId,
+    logLevel: overrides.logLevel,
+  });
+
+  // Handle graceful shutdown
+  const shutdown = async () => {
+    console.log('\nShutting down Telegram channel...');
+    await channel.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  await channel.start();
+  return channel;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,3 +104,6 @@ export type {
   CloudWorkspaceConfig,
   WorkspaceToolConfig,
 } from './workspace.js';
+
+export { TelegramChannel, startTelegramChannel } from './channels/telegram.js';
+export type { TelegramChannelConfig } from './channels/telegram.js';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/sandbox.ts',
     'src/mcp-server.ts',
     'src/workspace.ts',
+    'src/channels/telegram.ts',
   ],
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Summary

Adds a complete Telegram messaging channel integration for AgentForge, enabling agents to communicate with users through Telegram bots.

## Changes

### Core Package (`@agentforge-ai/core`)

- **`packages/core/src/channels/telegram.ts`** — New `TelegramChannel` class that bridges the existing `TelegramAdapter` with the Convex chat execution pipeline (`chat:sendMessage`, `chat:createThread`)
  - Routes incoming Telegram messages through the agent execution pipeline
  - Auto-creates Convex threads per Telegram chat with persistent thread mapping
  - Stores all messages in the Convex messages table
  - Handles `/start`, `/new`, `/help` bot commands
  - Splits long agent responses to respect Telegram's 4096 character limit
  - Sends typing indicators while the agent processes
  - Supports both webhook and long-polling modes
  - Configurable log levels (debug, info, warn, error)
- **`packages/core/src/channels/telegram.test.ts`** — Comprehensive test suite
- **`packages/core/src/index.ts`** — Export `TelegramChannel` and `startTelegramChannel`
- **`packages/core/package.json`** — Add `./channels/telegram` export path
- **`packages/core/tsup.config.ts`** — Add `channels/telegram` build entry

### CLI Package (`@agentforge-ai/cli`)

- **`packages/cli/src/commands/channel-telegram.ts`** — New CLI command with 3 subcommands:
  - `agentforge channel:telegram start` — Start the Telegram bot with agent routing
  - `agentforge channel:telegram configure` — Interactive setup for bot token and settings
  - `agentforge channel:telegram status` — Check bot configuration and connectivity
  - Built-in minimal Telegram bot runner as fallback when core package is not available
- **`packages/cli/src/index.ts`** — Register the new command

## Architecture

```
Telegram User → Telegram Bot API → TelegramAdapter (polling/webhook)
  → TelegramChannel.handleIncomingMessage()
    → Convex chat:createThread (if new chat)
    → Convex chat:sendMessage (routes to Mastra agent)
    → TelegramAdapter.sendMessage() → Telegram User
```

## Testing

- All 228 tests pass (9 test files)
- Core and CLI packages build successfully
- Type checking passes (only pre-existing errors in cloud-client.ts and mastra.ts)

## Usage

```bash
# Configure the bot token
agentforge channel:telegram configure

# Start the bot
agentforge channel:telegram start --agent <agent-id>

# Check status
agentforge channel:telegram status
```

## Configuration

Set `TELEGRAM_BOT_TOKEN` in `.env.local` or pass via `--token` flag.

Closes: Linear issue for Telegram channel feature
