### PR TITLE
feat(mcp): MCP-Native Architecture — client SDK, dynamic tool loading, SSE (AGE-9, AGE-80)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,6 +115,8 @@ export type { TelegramChannelConfig } from './channels/telegram.js';
 export { WhatsAppChannel, startWhatsAppChannel } from './channels/whatsapp.js';
 export type { WhatsAppChannelConfig } from './channels/whatsapp.js';
 
+export * from './mcp/index.js';
+
 export { A2AAgentRegistry, A2AClient, A2AServer } from './a2a/index.js';
 export type {
   A2ATask,

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,0 +1,25 @@
+export { MCPClient } from './mcp-client.js';
+export type {
+  MCPClientConfig,
+  MCPTransportConfig,
+  MCPConnectionState,
+  MCPClientEvent,
+  MCPClientEventHandler,
+} from './mcp-client.js';
+export type {
+  MCPToolDefinition,
+  MCPResourceDefinition,
+  MCPPromptDefinition,
+  MCPResourceContent,
+  MCPToolResult,
+  MCPPromptMessage,
+} from './mcp-client.js';
+export type {
+  MCPTransport,
+  MCPJsonRpcRequest,
+  MCPJsonRpcResponse,
+  MCPJsonRpcNotification,
+} from './mcp-client.js';
+export { StdioTransport, HttpTransport, SSETransport } from './mcp-client.js';
+export { mcpTransportConfigSchema } from './mcp-client.js';
+export { MCPDynamicToolLoader, jsonSchemaToZod } from './mcp-dynamic-tools.js';

--- a/packages/core/src/mcp/mcp-client.test.ts
+++ b/packages/core/src/mcp/mcp-client.test.ts
@@ -1,0 +1,795 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  MCPClient,
+  mcpTransportConfigSchema,
+  type MCPTransport,
+  type MCPJsonRpcRequest,
+  type MCPJsonRpcResponse,
+  type MCPJsonRpcNotification,
+  type MCPClientConfig,
+  type MCPToolDefinition,
+  type MCPResourceDefinition,
+  type MCPPromptDefinition,
+  type MCPToolResult,
+  type MCPResourceContent,
+  type MCPPromptMessage,
+} from './mcp-client.js';
+
+// === Mock Transport ===
+
+function createMockTransport(overrides?: Partial<MCPTransport>): MCPTransport {
+  let connected = false;
+  let notificationHandler: ((n: MCPJsonRpcNotification) => void) | undefined;
+
+  return {
+    connect: vi.fn(async () => {
+      connected = true;
+    }),
+    disconnect: vi.fn(async () => {
+      connected = false;
+    }),
+    send: vi.fn(async (msg: MCPJsonRpcRequest): Promise<MCPJsonRpcResponse> => {
+      if (msg.method === 'initialize') {
+        return {
+          jsonrpc: '2.0',
+          id: msg.id,
+          result: {
+            protocolVersion: '2024-11-05',
+            serverInfo: { name: 'test-server', version: '1.0.0' },
+            capabilities: { tools: {}, resources: {}, prompts: {} },
+          },
+        };
+      }
+      return { jsonrpc: '2.0', id: msg.id, result: {} };
+    }),
+    onNotification: vi.fn((handler: (n: MCPJsonRpcNotification) => void) => {
+      notificationHandler = handler;
+    }),
+    isConnected: vi.fn(() => connected),
+    // Expose handler for test use
+    get _notificationHandler() {
+      return notificationHandler;
+    },
+    ...overrides,
+  };
+}
+
+function createClientWithMock(
+  transportOverrides?: Partial<MCPTransport>,
+  configOverrides?: Partial<MCPClientConfig>,
+) {
+  const transport = createMockTransport(transportOverrides);
+
+  // We need to intercept the transport creation inside MCPClient.
+  // Since MCPClient internally creates transport from config, we mock at the module level.
+  // Instead, test via the public API with real transport configs + mock fetch.
+
+  // For unit testing, we test the schemas and protocol logic directly.
+  return { transport };
+}
+
+// === Schema Validation Tests ===
+
+describe('MCPTransportConfig Schema', () => {
+  describe('stdio transport', () => {
+    it('accepts valid stdio config', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'stdio',
+        command: 'node',
+        args: ['server.js'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts stdio config with env and cwd', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'stdio',
+        command: 'python',
+        args: ['-m', 'mcp_server'],
+        env: { PATH: '/usr/bin' },
+        cwd: '/tmp',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects stdio config without command', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'stdio',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects stdio config with non-string command', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'stdio',
+        command: 123,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects stdio config with invalid args type', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'stdio',
+        command: 'node',
+        args: 'not-an-array',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('http transport', () => {
+    it('accepts valid http config', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'http',
+        url: 'https://example.com/mcp',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts http config with headers and timeout', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'http',
+        url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer token' },
+        timeout: 5000,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects http config without url', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'http',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http config with invalid url', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'http',
+        url: 'not-a-url',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http config with non-positive timeout', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'http',
+        url: 'https://example.com/mcp',
+        timeout: -1,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http config with zero timeout', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'http',
+        url: 'https://example.com/mcp',
+        timeout: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('sse transport', () => {
+    it('accepts valid sse config', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/sse',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts sse config with all options', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/sse',
+        headers: { 'X-API-Key': 'key123' },
+        reconnectInterval: 5000,
+        maxReconnectAttempts: 10,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects sse config without url', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'sse',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects sse config with invalid url', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'sse',
+        url: 'not-a-url',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects sse config with negative reconnectInterval', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/sse',
+        reconnectInterval: -100,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects sse config with negative maxReconnectAttempts', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/sse',
+        maxReconnectAttempts: -1,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('discriminated union', () => {
+    it('rejects unknown transport type', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'websocket',
+        url: 'ws://example.com',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty object', () => {
+      const result = mcpTransportConfigSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+// === MCPClient Tests (with mocked fetch for HTTP transport) ===
+
+describe('MCPClient', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockFetchResponse(result: unknown, id?: string | number) {
+    return vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: id ?? body.id,
+          result,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+  }
+
+  function createHttpClient(config?: Partial<MCPClientConfig>): MCPClient {
+    return new MCPClient({
+      transport: { type: 'http', url: 'https://mcp.test/rpc' },
+      requestTimeout: 5000,
+      ...config,
+    });
+  }
+
+  describe('connect() / disconnect()', () => {
+    it('connects successfully with HTTP transport', async () => {
+      fetchMock.mockImplementation(
+        mockFetchResponse({
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test-server', version: '1.0.0' },
+          capabilities: {},
+        }),
+      );
+
+      const client = createHttpClient();
+      await client.connect();
+
+      expect(client.getState()).toBe('connected');
+      expect(client.getServerInfo()).toEqual({ name: 'test-server', version: '1.0.0' });
+    });
+
+    it('emits connected event on successful connect', async () => {
+      fetchMock.mockImplementation(
+        mockFetchResponse({
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test-server', version: '2.0.0' },
+          capabilities: {},
+        }),
+      );
+
+      const client = createHttpClient();
+      const events: unknown[] = [];
+      client.on((e) => events.push(e));
+
+      await client.connect();
+
+      expect(events).toContainEqual({
+        type: 'connected',
+        serverInfo: { name: 'test-server', version: '2.0.0' },
+      });
+    });
+
+    it('disconnects and resets state', async () => {
+      fetchMock.mockImplementation(
+        mockFetchResponse({
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test-server', version: '1.0.0' },
+          capabilities: {},
+        }),
+      );
+
+      const client = createHttpClient();
+      await client.connect();
+      await client.disconnect();
+
+      expect(client.getState()).toBe('disconnected');
+      expect(client.getServerInfo()).toBeNull();
+    });
+
+    it('emits disconnected event on disconnect', async () => {
+      fetchMock.mockImplementation(
+        mockFetchResponse({
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test-server', version: '1.0.0' },
+          capabilities: {},
+        }),
+      );
+
+      const client = createHttpClient();
+      await client.connect();
+
+      const events: unknown[] = [];
+      client.on((e) => events.push(e));
+      await client.disconnect();
+
+      expect(events).toContainEqual(expect.objectContaining({ type: 'disconnected' }));
+    });
+
+    it('is a no-op if already connected', async () => {
+      fetchMock.mockImplementation(
+        mockFetchResponse({
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test-server', version: '1.0.0' },
+          capabilities: {},
+        }),
+      );
+
+      const client = createHttpClient();
+      await client.connect();
+      await client.connect(); // second call is a no-op
+
+      expect(client.getState()).toBe('connected');
+    });
+
+    it('sets state to error on connection failure', async () => {
+      fetchMock.mockRejectedValue(new Error('Connection refused'));
+
+      const client = createHttpClient();
+      await expect(client.connect()).rejects.toThrow('Connection refused');
+      expect(client.getState()).toBe('error');
+    });
+
+    it('emits error event on connection failure', async () => {
+      fetchMock.mockRejectedValue(new Error('Connection refused'));
+
+      const client = createHttpClient();
+      const events: unknown[] = [];
+      client.on((e) => events.push(e));
+
+      await expect(client.connect()).rejects.toThrow();
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: 'error' }),
+      );
+    });
+  });
+
+  describe('listTools()', () => {
+    it('returns array of MCPToolDefinition', async () => {
+      const tools: MCPToolDefinition[] = [
+        { name: 'read_file', description: 'Read a file', inputSchema: { type: 'object', properties: { path: { type: 'string' } } } },
+        { name: 'write_file', description: 'Write a file', inputSchema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } } } },
+      ];
+
+      let callCount = 0;
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        callCount++;
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2024-11-05',
+                serverInfo: { name: 'test', version: '1.0.0' },
+                capabilities: {},
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        // tools/list or notifications/initialized
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { tools } }),
+          { status: 200 },
+        );
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      const result = await client.listTools();
+
+      expect(result).toEqual(tools);
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns empty array when server has no tools', async () => {
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2024-11-05',
+                serverInfo: { name: 'test', version: '1.0.0' },
+                capabilities: {},
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { tools: [] } }),
+          { status: 200 },
+        );
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      const result = await client.listTools();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('callTool()', () => {
+    function setupConnectedClient() {
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2024-11-05',
+                serverInfo: { name: 'test', version: '1.0.0' },
+                capabilities: {},
+              },
+            }),
+            { status: 200 },
+          );
+        }
+
+        if (body.method === 'tools/call') {
+          const toolResult: MCPToolResult = {
+            content: [{ type: 'text', text: `Result for ${body.params.name}` }],
+          };
+          return new Response(
+            JSON.stringify({ jsonrpc: '2.0', id: body.id, result: toolResult }),
+            { status: 200 },
+          );
+        }
+
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: {} }),
+          { status: 200 },
+        );
+      });
+    }
+
+    it('calls the right protocol message with tool name and args', async () => {
+      setupConnectedClient();
+
+      const client = createHttpClient();
+      await client.connect();
+      const result = await client.callTool('read_file', { path: '/tmp/test.txt' });
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'Result for read_file' }],
+      });
+
+      // Verify the request was made with correct method
+      const calls = fetchMock.mock.calls;
+      const toolCall = calls.find((c: unknown[]) => {
+        const body = JSON.parse(c[1]?.body as string);
+        return body.method === 'tools/call';
+      });
+      expect(toolCall).toBeDefined();
+      const toolBody = JSON.parse(toolCall![1]?.body as string);
+      expect(toolBody.params.name).toBe('read_file');
+      expect(toolBody.params.arguments).toEqual({ path: '/tmp/test.txt' });
+    });
+
+    it('sends empty arguments when none provided', async () => {
+      setupConnectedClient();
+
+      const client = createHttpClient();
+      await client.connect();
+      await client.callTool('ping');
+
+      const calls = fetchMock.mock.calls;
+      const toolCall = calls.find((c: unknown[]) => {
+        const body = JSON.parse(c[1]?.body as string);
+        return body.method === 'tools/call';
+      });
+      const toolBody = JSON.parse(toolCall![1]?.body as string);
+      expect(toolBody.params.arguments).toEqual({});
+    });
+  });
+
+  describe('listResources()', () => {
+    it('returns array of MCPResourceDefinition', async () => {
+      const resources: MCPResourceDefinition[] = [
+        { uri: 'file:///tmp/config.json', name: 'config', description: 'Config file', mimeType: 'application/json' },
+      ];
+
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0', id: body.id,
+              result: { protocolVersion: '2024-11-05', serverInfo: { name: 'test', version: '1.0.0' }, capabilities: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { resources } }),
+          { status: 200 },
+        );
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      const result = await client.listResources();
+
+      expect(result).toEqual(resources);
+    });
+  });
+
+  describe('readResource()', () => {
+    it('reads resource by URI', async () => {
+      const contents: MCPResourceContent[] = [
+        { uri: 'file:///tmp/data.txt', mimeType: 'text/plain', text: 'hello world' },
+      ];
+
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0', id: body.id,
+              result: { protocolVersion: '2024-11-05', serverInfo: { name: 'test', version: '1.0.0' }, capabilities: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { contents } }),
+          { status: 200 },
+        );
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      const result = await client.readResource('file:///tmp/data.txt');
+
+      expect(result).toEqual(contents);
+    });
+  });
+
+  describe('listPrompts()', () => {
+    it('returns array of MCPPromptDefinition', async () => {
+      const prompts: MCPPromptDefinition[] = [
+        { name: 'summarize', description: 'Summarize text', arguments: [{ name: 'text', required: true }] },
+      ];
+
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0', id: body.id,
+              result: { protocolVersion: '2024-11-05', serverInfo: { name: 'test', version: '1.0.0' }, capabilities: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { prompts } }),
+          { status: 200 },
+        );
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      const result = await client.listPrompts();
+
+      expect(result).toEqual(prompts);
+    });
+  });
+
+  describe('getPrompt()', () => {
+    it('returns prompt messages', async () => {
+      const messages: MCPPromptMessage[] = [
+        { role: 'user', content: { type: 'text', text: 'Summarize: hello world' } },
+      ];
+
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0', id: body.id,
+              result: { protocolVersion: '2024-11-05', serverInfo: { name: 'test', version: '1.0.0' }, capabilities: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { messages } }),
+          { status: 200 },
+        );
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      const result = await client.getPrompt('summarize', { text: 'hello world' });
+
+      expect(result).toEqual(messages);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on protocol error from server', async () => {
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0', id: body.id,
+              result: { protocolVersion: '2024-11-05', serverInfo: { name: 'test', version: '1.0.0' }, capabilities: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: body.id,
+            error: { code: -32601, message: 'Method not found' },
+          }),
+          { status: 200 },
+        );
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      await expect(client.listTools()).rejects.toThrow('MCP error -32601: Method not found');
+    });
+
+    it('throws on HTTP error response', async () => {
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0', id: body.id,
+              result: { protocolVersion: '2024-11-05', serverInfo: { name: 'test', version: '1.0.0' }, capabilities: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response('Internal Server Error', { status: 500, statusText: 'Internal Server Error' });
+      });
+
+      const client = createHttpClient();
+      await client.connect();
+      await expect(client.listTools()).rejects.toThrow('HTTP request failed: 500');
+    });
+
+    it('throws on request timeout', async () => {
+      fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        if (body.method === 'initialize') {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0', id: body.id,
+              result: { protocolVersion: '2024-11-05', serverInfo: { name: 'test', version: '1.0.0' }, capabilities: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        // Simulate timeout - never resolve
+        return new Promise(() => {});
+      });
+
+      const client = createHttpClient({ requestTimeout: 100 });
+      await client.connect();
+      await expect(client.listTools()).rejects.toThrow(/timed out/);
+    });
+
+    it('rejects invalid transport config in constructor', () => {
+      expect(() => {
+        new MCPClient({
+          transport: { type: 'invalid' } as any,
+        });
+      }).toThrow();
+    });
+  });
+
+  describe('event system', () => {
+    it('on() returns unsubscribe function', async () => {
+      fetchMock.mockImplementation(
+        mockFetchResponse({
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test', version: '1.0.0' },
+          capabilities: {},
+        }),
+      );
+
+      const client = createHttpClient();
+      const events: unknown[] = [];
+      const unsub = client.on((e) => events.push(e));
+
+      await client.connect();
+      expect(events.length).toBeGreaterThan(0);
+
+      unsub();
+      const countBefore = events.length;
+      await client.disconnect();
+      // After unsubscribe, should not receive more events
+      expect(events.length).toBe(countBefore);
+    });
+
+    it('swallows errors thrown by event handlers', async () => {
+      fetchMock.mockImplementation(
+        mockFetchResponse({
+          protocolVersion: '2024-11-05',
+          serverInfo: { name: 'test', version: '1.0.0' },
+          capabilities: {},
+        }),
+      );
+
+      const client = createHttpClient();
+      client.on(() => {
+        throw new Error('handler error');
+      });
+
+      // Should not throw
+      await expect(client.connect()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('SSE transport config', () => {
+    it('accepts zero for maxReconnectAttempts', () => {
+      const result = mcpTransportConfigSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/sse',
+        maxReconnectAttempts: 0,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/mcp/mcp-client.ts
+++ b/packages/core/src/mcp/mcp-client.ts
@@ -1,0 +1,759 @@
+import { z } from 'zod';
+import { spawn, type ChildProcess } from 'child_process';
+
+// === Schemas (Zod) ===
+export const mcpTransportConfigSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('stdio'),
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string()).optional(),
+    cwd: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('http'),
+    url: z.string().url(),
+    headers: z.record(z.string()).optional(),
+    timeout: z.number().positive().optional(),
+  }),
+  z.object({
+    type: z.literal('sse'),
+    url: z.string().url(),
+    headers: z.record(z.string()).optional(),
+    reconnectInterval: z.number().positive().optional(),
+    maxReconnectAttempts: z.number().nonnegative().optional(),
+  }),
+]);
+
+export type MCPTransportConfig = z.infer<typeof mcpTransportConfigSchema>;
+
+// MCP Protocol types
+export interface MCPToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>; // JSON Schema
+}
+
+export interface MCPResourceDefinition {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+export interface MCPPromptDefinition {
+  name: string;
+  description?: string;
+  arguments?: Array<{
+    name: string;
+    description?: string;
+    required?: boolean;
+  }>;
+}
+
+export interface MCPResourceContent {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string; // base64
+}
+
+export interface MCPToolResult {
+  content: Array<{
+    type: 'text' | 'image' | 'resource';
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  }>;
+  isError?: boolean;
+}
+
+export interface MCPPromptMessage {
+  role: 'user' | 'assistant';
+  content: {
+    type: 'text' | 'image' | 'resource';
+    text?: string;
+  };
+}
+
+// Client configuration
+export interface MCPClientConfig {
+  transport: MCPTransportConfig;
+  clientInfo?: {
+    name: string;
+    version: string;
+  };
+  capabilities?: {
+    tools?: boolean;
+    resources?: boolean;
+    prompts?: boolean;
+  };
+  requestTimeout?: number; // ms, default 30000
+}
+
+// Connection state
+export type MCPConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+// Events
+export type MCPClientEvent =
+  | { type: 'connected'; serverInfo: { name: string; version: string } }
+  | { type: 'disconnected'; reason?: string }
+  | { type: 'error'; error: Error }
+  | { type: 'toolsChanged' }
+  | { type: 'resourcesChanged' };
+
+export type MCPClientEventHandler = (event: MCPClientEvent) => void;
+
+// === Transport Interface ===
+export interface MCPTransport {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  send(message: MCPJsonRpcRequest): Promise<MCPJsonRpcResponse>;
+  onNotification?(handler: (notification: MCPJsonRpcNotification) => void): void;
+  isConnected(): boolean;
+}
+
+// JSON-RPC types for MCP protocol
+export interface MCPJsonRpcRequest {
+  jsonrpc: '2.0';
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface MCPJsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export interface MCPJsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+// === StdioTransport ===
+
+export class StdioTransport implements MCPTransport {
+  private process: ChildProcess | null = null;
+  private connected = false;
+  private pendingRequests = new Map<
+    string | number,
+    { resolve: (res: MCPJsonRpcResponse) => void; reject: (err: Error) => void }
+  >();
+  private notificationHandler: ((n: MCPJsonRpcNotification) => void) | undefined;
+  private buffer = '';
+
+  constructor(private readonly config: Extract<MCPTransportConfig, { type: 'stdio' }>) {}
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+
+    return new Promise((resolve, reject) => {
+      const env = this.config.env
+        ? { ...process.env, ...this.config.env }
+        : process.env;
+
+      this.process = spawn(this.config.command, this.config.args ?? [], {
+        cwd: this.config.cwd,
+        env: env as NodeJS.ProcessEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      this.process.on('error', (err) => {
+        this.connected = false;
+        reject(new Error(`Failed to spawn process "${this.config.command}": ${err.message}`));
+      });
+
+      this.process.stdout!.on('data', (chunk: Buffer) => {
+        this.buffer += chunk.toString('utf8');
+        this.flushBuffer();
+      });
+
+      this.process.stderr!.on('data', (_chunk: Buffer) => {
+        // stderr is informational; ignore for protocol
+      });
+
+      this.process.on('exit', (code) => {
+        this.connected = false;
+        const reason = `Process exited with code ${code}`;
+        for (const pending of this.pendingRequests.values()) {
+          pending.reject(new Error(reason));
+        }
+        this.pendingRequests.clear();
+      });
+
+      // Give the process a tick to fail on spawn errors
+      setImmediate(() => {
+        if (this.process && !this.process.killed) {
+          this.connected = true;
+          resolve();
+        }
+      });
+    });
+  }
+
+  private flushBuffer(): void {
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const msg = JSON.parse(trimmed) as MCPJsonRpcResponse | MCPJsonRpcNotification;
+        if ('id' in msg && msg.id !== undefined && msg.id !== null) {
+          const pending = this.pendingRequests.get((msg as MCPJsonRpcResponse).id);
+          if (pending) {
+            this.pendingRequests.delete((msg as MCPJsonRpcResponse).id);
+            pending.resolve(msg as MCPJsonRpcResponse);
+          }
+        } else if ('method' in msg) {
+          this.notificationHandler?.(msg as MCPJsonRpcNotification);
+        }
+      } catch {
+        // Malformed JSON — skip
+      }
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.process) return;
+    this.connected = false;
+    this.process.kill();
+    this.process = null;
+    this.pendingRequests.clear();
+  }
+
+  async send(message: MCPJsonRpcRequest): Promise<MCPJsonRpcResponse> {
+    if (!this.connected || !this.process) {
+      throw new Error('StdioTransport is not connected');
+    }
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(message.id, { resolve, reject });
+      const line = JSON.stringify(message) + '\n';
+      this.process!.stdin!.write(line, (err) => {
+        if (err) {
+          this.pendingRequests.delete(message.id);
+          reject(new Error(`Failed to write to stdin: ${err.message}`));
+        }
+      });
+    });
+  }
+
+  onNotification(handler: (notification: MCPJsonRpcNotification) => void): void {
+    this.notificationHandler = handler;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}
+
+// === HttpTransport ===
+
+export class HttpTransport implements MCPTransport {
+  private connected = false;
+
+  constructor(private readonly config: Extract<MCPTransportConfig, { type: 'http' }>) {}
+
+  async connect(): Promise<void> {
+    // HTTP is stateless; mark connected immediately
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+
+  async send(message: MCPJsonRpcRequest): Promise<MCPJsonRpcResponse> {
+    if (!this.connected) {
+      throw new Error('HttpTransport is not connected');
+    }
+
+    const timeout = this.config.timeout ?? 30_000;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const response = await fetch(this.config.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.config.headers,
+        },
+        body: JSON.stringify(message),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `HTTP request failed: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const data = (await response.json()) as MCPJsonRpcResponse;
+      return data;
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        throw new Error(`HTTP request timed out after ${timeout}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}
+
+// === SSETransport ===
+
+interface PendingSSERequest {
+  resolve: (res: MCPJsonRpcResponse) => void;
+  reject: (err: Error) => void;
+}
+
+export class SSETransport implements MCPTransport {
+  private connected = false;
+  private pendingRequests = new Map<string | number, PendingSSERequest>();
+  private notificationHandler: ((n: MCPJsonRpcNotification) => void) | undefined;
+  private abortController: AbortController | null = null;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private messageEndpoint: string;
+
+  constructor(private readonly config: Extract<MCPTransportConfig, { type: 'sse' }>) {
+    // Convention: SSE messages are sent via POST to <url>/message
+    const base = config.url.replace(/\/$/, '');
+    this.messageEndpoint = `${base}/message`;
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+    await this.openSSEStream();
+  }
+
+  private async openSSEStream(): Promise<void> {
+    this.abortController = new AbortController();
+
+    const response = await fetch(this.config.url, {
+      method: 'GET',
+      headers: {
+        Accept: 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        ...this.config.headers,
+      },
+      signal: this.abortController.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `SSE connection failed: ${response.status} ${response.statusText}`
+      );
+    }
+
+    if (!response.body) {
+      throw new Error('SSE response has no body');
+    }
+
+    this.connected = true;
+    this.reconnectAttempts = 0;
+
+    // Parse SSE stream asynchronously
+    void this.parseSSEStream(response.body);
+  }
+
+  private async parseSSEStream(body: ReadableStream<Uint8Array>): Promise<void> {
+    const decoder = new TextDecoder();
+    const reader = body.getReader();
+    let buffer = '';
+    let eventData = '';
+    let eventType = 'message';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (line === '') {
+            // Dispatch event
+            if (eventData) {
+              this.handleSSEEvent(eventType, eventData);
+            }
+            eventData = '';
+            eventType = 'message';
+          } else if (line.startsWith('data:')) {
+            const data = line.slice(5).trimStart();
+            eventData = eventData ? `${eventData}\n${data}` : data;
+          } else if (line.startsWith('event:')) {
+            eventType = line.slice(6).trim();
+          }
+          // id: and retry: fields are parsed but not used in this implementation
+        }
+      }
+    } catch (err) {
+      const error = err as Error;
+      if (error.name === 'AbortError') return;
+
+      this.connected = false;
+      await this.scheduleReconnect();
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Stream ended normally — attempt reconnect
+    if (this.connected) {
+      this.connected = false;
+      await this.scheduleReconnect();
+    }
+  }
+
+  private handleSSEEvent(eventType: string, data: string): void {
+    try {
+      const msg = JSON.parse(data) as MCPJsonRpcResponse | MCPJsonRpcNotification;
+
+      if ('id' in msg && msg.id !== undefined && msg.id !== null) {
+        const pending = this.pendingRequests.get((msg as MCPJsonRpcResponse).id);
+        if (pending) {
+          this.pendingRequests.delete((msg as MCPJsonRpcResponse).id);
+          pending.resolve(msg as MCPJsonRpcResponse);
+        }
+      } else if ('method' in msg && eventType !== 'response') {
+        this.notificationHandler?.(msg as MCPJsonRpcNotification);
+      }
+    } catch {
+      // Malformed JSON — skip
+    }
+  }
+
+  private async scheduleReconnect(): Promise<void> {
+    const maxAttempts = this.config.maxReconnectAttempts ?? 5;
+    const interval = this.config.reconnectInterval ?? 3_000;
+
+    if (this.reconnectAttempts >= maxAttempts) {
+      const err = new Error(
+        `SSE reconnection failed after ${maxAttempts} attempts`
+      );
+      for (const pending of this.pendingRequests.values()) {
+        pending.reject(err);
+      }
+      this.pendingRequests.clear();
+      return;
+    }
+
+    this.reconnectAttempts++;
+    await new Promise<void>((resolve) => {
+      this.reconnectTimer = setTimeout(resolve, interval);
+    });
+
+    try {
+      await this.openSSEStream();
+    } catch {
+      await this.scheduleReconnect();
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.abortController?.abort();
+    this.abortController = null;
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(new Error('SSETransport disconnected'));
+    }
+    this.pendingRequests.clear();
+  }
+
+  async send(message: MCPJsonRpcRequest): Promise<MCPJsonRpcResponse> {
+    if (!this.connected) {
+      throw new Error('SSETransport is not connected');
+    }
+
+    // For SSE, responses arrive via the SSE stream; we POST the request separately
+    return new Promise(async (resolve, reject) => {
+      this.pendingRequests.set(message.id, { resolve, reject });
+      try {
+        const response = await fetch(this.messageEndpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...this.config.headers,
+          },
+          body: JSON.stringify(message),
+        });
+        if (!response.ok) {
+          this.pendingRequests.delete(message.id);
+          reject(
+            new Error(
+              `SSE message POST failed: ${response.status} ${response.statusText}`
+            )
+          );
+        }
+      } catch (err) {
+        this.pendingRequests.delete(message.id);
+        reject(err);
+      }
+    });
+  }
+
+  onNotification(handler: (notification: MCPJsonRpcNotification) => void): void {
+    this.notificationHandler = handler;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}
+
+// === Factory ===
+
+function createTransport(config: MCPTransportConfig): MCPTransport {
+  switch (config.type) {
+    case 'stdio':
+      return new StdioTransport(config);
+    case 'http':
+      return new HttpTransport(config);
+    case 'sse':
+      return new SSETransport(config);
+  }
+}
+
+// === MCP Client Class ===
+
+export class MCPClient {
+  private transport: MCPTransport;
+  private config: MCPClientConfig;
+  private state: MCPConnectionState = 'disconnected';
+  private serverInfo: { name: string; version: string } | null = null;
+  private eventHandlers: Set<MCPClientEventHandler> = new Set();
+  private requestCounter = 0;
+
+  constructor(config: MCPClientConfig) {
+    // Validate transport config
+    mcpTransportConfigSchema.parse(config.transport);
+    this.config = config;
+    this.transport = createTransport(config.transport);
+
+    // Wire up notifications
+    this.transport.onNotification?.((notification) => {
+      if (notification.method === 'notifications/tools/list_changed') {
+        this.emit({ type: 'toolsChanged' });
+      } else if (notification.method === 'notifications/resources/list_changed') {
+        this.emit({ type: 'resourcesChanged' });
+      }
+    });
+  }
+
+  // === Lifecycle ===
+
+  async connect(): Promise<void> {
+    if (this.state === 'connected') return;
+
+    this.state = 'connecting';
+    try {
+      await this.transport.connect();
+
+      // MCP initialize handshake
+      const initResult = await this.sendRequest('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {
+          tools: this.config.capabilities?.tools !== false ? {} : undefined,
+          resources: this.config.capabilities?.resources !== false ? {} : undefined,
+          prompts: this.config.capabilities?.prompts !== false ? {} : undefined,
+        },
+        clientInfo: this.config.clientInfo ?? {
+          name: 'agentforge-mcp-client',
+          version: '1.0.0',
+        },
+      });
+
+      const init = initResult as {
+        protocolVersion: string;
+        serverInfo: { name: string; version: string };
+        capabilities?: Record<string, unknown>;
+      };
+
+      this.serverInfo = init.serverInfo;
+      this.state = 'connected';
+
+      // Send initialized notification (fire-and-forget)
+      void this.sendNotification('notifications/initialized');
+
+      this.emit({ type: 'connected', serverInfo: this.serverInfo });
+    } catch (err) {
+      this.state = 'error';
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emit({ type: 'error', error });
+      throw error;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    await this.transport.disconnect();
+    this.state = 'disconnected';
+    this.serverInfo = null;
+    this.emit({ type: 'disconnected' });
+  }
+
+  getState(): MCPConnectionState {
+    return this.state;
+  }
+
+  getServerInfo(): { name: string; version: string } | null {
+    return this.serverInfo;
+  }
+
+  // === MCP Protocol Methods ===
+
+  async listTools(): Promise<MCPToolDefinition[]> {
+    const result = await this.sendRequest('tools/list');
+    const typed = result as { tools: MCPToolDefinition[] };
+    return typed.tools ?? [];
+  }
+
+  async callTool(name: string, args?: Record<string, unknown>): Promise<MCPToolResult> {
+    const result = await this.sendRequest('tools/call', {
+      name,
+      arguments: args ?? {},
+    });
+    return result as MCPToolResult;
+  }
+
+  async listResources(): Promise<MCPResourceDefinition[]> {
+    const result = await this.sendRequest('resources/list');
+    const typed = result as { resources: MCPResourceDefinition[] };
+    return typed.resources ?? [];
+  }
+
+  async readResource(uri: string): Promise<MCPResourceContent[]> {
+    const result = await this.sendRequest('resources/read', { uri });
+    const typed = result as { contents: MCPResourceContent[] };
+    return typed.contents ?? [];
+  }
+
+  async listPrompts(): Promise<MCPPromptDefinition[]> {
+    const result = await this.sendRequest('prompts/list');
+    const typed = result as { prompts: MCPPromptDefinition[] };
+    return typed.prompts ?? [];
+  }
+
+  async getPrompt(
+    name: string,
+    args?: Record<string, unknown>
+  ): Promise<MCPPromptMessage[]> {
+    const result = await this.sendRequest('prompts/get', {
+      name,
+      arguments: args ?? {},
+    });
+    const typed = result as { messages: MCPPromptMessage[] };
+    return typed.messages ?? [];
+  }
+
+  // === Events ===
+
+  on(handler: MCPClientEventHandler): () => void {
+    this.eventHandlers.add(handler);
+    return () => {
+      this.eventHandlers.delete(handler);
+    };
+  }
+
+  // === Internal ===
+
+  private nextId(): string {
+    this.requestCounter++;
+    return crypto.randomUUID();
+  }
+
+  private async sendRequest(
+    method: string,
+    params?: Record<string, unknown>
+  ): Promise<unknown> {
+    const timeout = this.config.requestTimeout ?? 30_000;
+    const id = this.nextId();
+
+    const request: MCPJsonRpcRequest = {
+      jsonrpc: '2.0',
+      id,
+      method,
+      ...(params !== undefined ? { params } : {}),
+    };
+
+    const responsePromise = this.transport.send(request);
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`Request "${method}" timed out after ${timeout}ms`)),
+        timeout
+      )
+    );
+
+    const response = await Promise.race([responsePromise, timeoutPromise]);
+
+    if (response.error) {
+      throw new Error(
+        `MCP error ${response.error.code}: ${response.error.message}`
+      );
+    }
+
+    return response.result;
+  }
+
+  private async sendNotification(
+    method: string,
+    params?: Record<string, unknown>
+  ): Promise<void> {
+    // Notifications have no id and expect no response.
+    // We construct a minimal message. For transports that require a request/response
+    // cycle we send with a throwaway id and discard the response.
+    const notification: MCPJsonRpcNotification = {
+      jsonrpc: '2.0',
+      method,
+      ...(params !== undefined ? { params } : {}),
+    };
+
+    // HttpTransport and SSETransport require a JSON-RPC request with id.
+    // We send as a request with a synthetic id and silently ignore the response.
+    if (this.transport instanceof HttpTransport || this.transport instanceof SSETransport) {
+      try {
+        await this.transport.send({
+          ...notification,
+          id: crypto.randomUUID(),
+        } as MCPJsonRpcRequest);
+      } catch {
+        // Notifications are fire-and-forget; swallow errors
+      }
+    } else if (this.transport instanceof StdioTransport) {
+      // For stdio we can write the raw notification (no id)
+      await this.transport.send({
+        ...notification,
+        id: crypto.randomUUID(),
+      } as MCPJsonRpcRequest);
+    }
+  }
+
+  private emit(event: MCPClientEvent): void {
+    for (const handler of this.eventHandlers) {
+      try {
+        handler(event);
+      } catch {
+        // Swallow handler errors
+      }
+    }
+  }
+}

--- a/packages/core/src/mcp/mcp-dynamic-tools.test.ts
+++ b/packages/core/src/mcp/mcp-dynamic-tools.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MCPDynamicToolLoader, jsonSchemaToZod } from './mcp-dynamic-tools.js';
+import type { MCPClient, MCPToolDefinition, MCPToolResult } from './mcp-client.js';
+import { z } from 'zod';
+
+// === Mock MCPClient ===
+
+function createMockClient(tools: MCPToolDefinition[] = []): MCPClient {
+  return {
+    listTools: vi.fn(async () => tools),
+    callTool: vi.fn(async (name: string, args?: Record<string, unknown>): Promise<MCPToolResult> => {
+      return {
+        content: [{ type: 'text', text: `Called ${name} with ${JSON.stringify(args)}` }],
+      };
+    }),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getState: vi.fn(() => 'connected' as const),
+    getServerInfo: vi.fn(() => ({ name: 'mock', version: '1.0.0' })),
+    listResources: vi.fn(async () => []),
+    readResource: vi.fn(async () => []),
+    listPrompts: vi.fn(async () => []),
+    getPrompt: vi.fn(async () => []),
+    on: vi.fn(() => () => {}),
+  } as unknown as MCPClient;
+}
+
+const sampleTools: MCPToolDefinition[] = [
+  {
+    name: 'read_file',
+    description: 'Read a file from disk',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+      },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'write_file',
+    description: 'Write content to a file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        content: { type: 'string' },
+      },
+      required: ['path', 'content'],
+    },
+  },
+  {
+    name: 'list_dir',
+    description: 'List directory contents',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        recursive: { type: 'boolean' },
+      },
+      required: ['path'],
+    },
+  },
+];
+
+// === jsonSchemaToZod Tests ===
+
+describe('jsonSchemaToZod', () => {
+  it('converts string type', () => {
+    const schema = jsonSchemaToZod({ type: 'string' });
+    expect(schema.safeParse('hello').success).toBe(true);
+    expect(schema.safeParse(123).success).toBe(false);
+  });
+
+  it('converts number type', () => {
+    const schema = jsonSchemaToZod({ type: 'number' });
+    expect(schema.safeParse(42).success).toBe(true);
+    expect(schema.safeParse('not-a-number').success).toBe(false);
+  });
+
+  it('converts integer as number', () => {
+    const schema = jsonSchemaToZod({ type: 'integer' });
+    expect(schema.safeParse(42).success).toBe(true);
+  });
+
+  it('converts boolean type', () => {
+    const schema = jsonSchemaToZod({ type: 'boolean' });
+    expect(schema.safeParse(true).success).toBe(true);
+    expect(schema.safeParse('true').success).toBe(false);
+  });
+
+  it('converts object with required and optional properties', () => {
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+      required: ['name'],
+    });
+    expect(schema.safeParse({ name: 'Alice' }).success).toBe(true);
+    expect(schema.safeParse({ name: 'Alice', age: 30 }).success).toBe(true);
+    expect(schema.safeParse({}).success).toBe(false); // missing required 'name'
+  });
+
+  it('converts empty object schema', () => {
+    const schema = jsonSchemaToZod({ type: 'object' });
+    expect(schema.safeParse({}).success).toBe(true);
+  });
+
+  it('converts array type', () => {
+    const schema = jsonSchemaToZod({ type: 'array', items: { type: 'string' } });
+    expect(schema.safeParse(['a', 'b']).success).toBe(true);
+    expect(schema.safeParse([1, 2]).success).toBe(false);
+  });
+
+  it('returns z.unknown() for unrecognized type', () => {
+    const schema = jsonSchemaToZod({ type: 'custom' });
+    expect(schema.safeParse('anything').success).toBe(true);
+    expect(schema.safeParse(42).success).toBe(true);
+  });
+});
+
+// === MCPDynamicToolLoader Tests ===
+
+describe('MCPDynamicToolLoader', () => {
+  let loader: MCPDynamicToolLoader;
+
+  beforeEach(() => {
+    loader = new MCPDynamicToolLoader();
+  });
+
+  afterEach(() => {
+    loader.unloadTools();
+  });
+
+  describe('loadTools()', () => {
+    it('wraps each MCP tool as a Mastra-compatible tool', async () => {
+      const client = createMockClient(sampleTools);
+      const tools = await loader.loadTools(client);
+
+      expect(Object.keys(tools)).toEqual(['read_file', 'write_file', 'list_dir']);
+      expect(client.listTools).toHaveBeenCalledOnce();
+    });
+
+    it('each tool has id, description, and execute', async () => {
+      const client = createMockClient(sampleTools);
+      const tools = await loader.loadTools(client);
+
+      const readFile = tools['read_file'];
+      expect(readFile).toBeDefined();
+      expect(readFile.id).toBe('mcp_read_file');
+      expect(readFile.description).toBe('Read a file from disk');
+      expect(typeof readFile.execute).toBe('function');
+    });
+
+    it('returns empty record when server has no tools', async () => {
+      const client = createMockClient([]);
+      const tools = await loader.loadTools(client);
+
+      expect(Object.keys(tools)).toHaveLength(0);
+    });
+
+    it('handles tools without inputSchema', async () => {
+      const client = createMockClient([
+        { name: 'ping', inputSchema: {} },
+      ]);
+      const tools = await loader.loadTools(client);
+
+      expect(tools['ping']).toBeDefined();
+    });
+  });
+
+  describe('tool execute()', () => {
+    it('delegates to MCPClient.callTool with correct name', async () => {
+      const client = createMockClient(sampleTools);
+      const tools = await loader.loadTools(client);
+
+      const result = await tools['read_file'].execute({ path: '/tmp/test.txt' });
+
+      expect(client.callTool).toHaveBeenCalledWith('read_file', { path: '/tmp/test.txt' });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'Called read_file with {"path":"/tmp/test.txt"}' }],
+      });
+    });
+
+    it('delegates with multiple arguments', async () => {
+      const client = createMockClient(sampleTools);
+      const tools = await loader.loadTools(client);
+
+      await tools['write_file'].execute({ path: '/tmp/out.txt', content: 'hello' });
+
+      expect(client.callTool).toHaveBeenCalledWith('write_file', {
+        path: '/tmp/out.txt',
+        content: 'hello',
+      });
+    });
+
+    it('propagates errors from callTool', async () => {
+      const client = createMockClient(sampleTools);
+      (client.callTool as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Tool execution failed'),
+      );
+
+      const tools = await loader.loadTools(client);
+      await expect(
+        tools['read_file'].execute({ path: '/tmp/test.txt' }),
+      ).rejects.toThrow('Tool execution failed');
+    });
+  });
+
+  describe('watchTools()', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('detects new tools on refresh', async () => {
+      const initialTools = [sampleTools[0]];
+      const updatedTools = [...sampleTools];
+
+      let callCount = 0;
+      const client = createMockClient(initialTools);
+      (client.listTools as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        callCount++;
+        return callCount === 1 ? initialTools : updatedTools;
+      });
+
+      await loader.loadTools(client);
+
+      const onUpdate = vi.fn();
+      loader.watchTools(client, onUpdate, 1000);
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(onUpdate).toHaveBeenCalledOnce();
+      const updatedToolRecord = onUpdate.mock.calls[0][0];
+      expect(Object.keys(updatedToolRecord)).toEqual(['read_file', 'write_file', 'list_dir']);
+    });
+
+    it('does not trigger onUpdate when tool list is unchanged', async () => {
+      const client = createMockClient(sampleTools);
+
+      await loader.loadTools(client);
+
+      const onUpdate = vi.fn();
+      loader.watchTools(client, onUpdate, 1000);
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('detects tool removal', async () => {
+      let callCount = 0;
+      const client = createMockClient(sampleTools);
+      (client.listTools as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        callCount++;
+        return callCount === 1 ? sampleTools : [sampleTools[0]];
+      });
+
+      await loader.loadTools(client);
+
+      const onUpdate = vi.fn();
+      loader.watchTools(client, onUpdate, 1000);
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(onUpdate).toHaveBeenCalledOnce();
+      const updatedToolRecord = onUpdate.mock.calls[0][0];
+      expect(Object.keys(updatedToolRecord)).toEqual(['read_file']);
+    });
+
+    it('silently handles errors during polling', async () => {
+      const client = createMockClient(sampleTools);
+      await loader.loadTools(client);
+
+      (client.listTools as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+
+      const onUpdate = vi.fn();
+      loader.watchTools(client, onUpdate, 1000);
+
+      // Should not throw
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unloadTools()', () => {
+    it('clears all loaded tools', async () => {
+      const client = createMockClient(sampleTools);
+      await loader.loadTools(client);
+
+      expect(Object.keys(loader.getTools())).toHaveLength(3);
+
+      loader.unloadTools();
+      expect(Object.keys(loader.getTools())).toHaveLength(0);
+    });
+
+    it('stops watching', async () => {
+      vi.useFakeTimers();
+
+      const client = createMockClient(sampleTools);
+      await loader.loadTools(client);
+
+      const onUpdate = vi.fn();
+      loader.watchTools(client, onUpdate, 1000);
+      loader.unloadTools();
+
+      // Change tool list
+      (client.listTools as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(onUpdate).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('can be called multiple times safely', () => {
+      expect(() => {
+        loader.unloadTools();
+        loader.unloadTools();
+      }).not.toThrow();
+    });
+  });
+
+  describe('getTools()', () => {
+    it('returns copy of tools record', async () => {
+      const client = createMockClient(sampleTools);
+      await loader.loadTools(client);
+
+      const tools1 = loader.getTools();
+      const tools2 = loader.getTools();
+      expect(tools1).toEqual(tools2);
+      expect(tools1).not.toBe(tools2); // different references
+    });
+  });
+});

--- a/packages/core/src/mcp/mcp-dynamic-tools.ts
+++ b/packages/core/src/mcp/mcp-dynamic-tools.ts
@@ -1,0 +1,138 @@
+import { createTool, type Tool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { MCPClient, MCPToolDefinition } from './mcp-client.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MastraTool = Tool<any, any, any, any, any, any, any>;
+
+/**
+ * Convert a JSON Schema object to a Zod schema.
+ * Handles: string, number, integer, boolean, object, array.
+ */
+export function jsonSchemaToZod(schema: Record<string, unknown>): z.ZodTypeAny {
+  const type = schema['type'] as string | undefined;
+
+  switch (type) {
+    case 'string':
+      return z.string();
+    case 'number':
+    case 'integer':
+      return z.number();
+    case 'boolean':
+      return z.boolean();
+    case 'object': {
+      const properties = schema['properties'] as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+      const required = schema['required'] as string[] | undefined;
+
+      if (!properties) return z.object({});
+
+      const shape: z.ZodRawShape = {};
+      for (const [key, propSchema] of Object.entries(properties)) {
+        const zodField = jsonSchemaToZod(propSchema);
+        shape[key] = required?.includes(key) ? zodField : zodField.optional();
+      }
+      return z.object(shape);
+    }
+    case 'array': {
+      const items = schema['items'] as Record<string, unknown> | undefined;
+      return z.array(items ? jsonSchemaToZod(items) : z.unknown());
+    }
+    default:
+      return z.unknown();
+  }
+}
+
+/**
+ * MCPDynamicToolLoader wraps MCP server tools as Mastra-compatible tools
+ * so they can be injected into any Mastra Agent at runtime.
+ */
+export class MCPDynamicToolLoader {
+  private tools: Record<string, MastraTool> = {};
+  private watchInterval: ReturnType<typeof setInterval> | null = null;
+  private lastToolNames: string[] = [];
+
+  /**
+   * Load all tools from an MCPClient and return them as Mastra-compatible tools.
+   */
+  async loadTools(client: MCPClient): Promise<Record<string, MastraTool>> {
+    const mcpTools = await client.listTools();
+    this.tools = {};
+
+    for (const mcpTool of mcpTools) {
+      this.tools[mcpTool.name] = this.wrapTool(client, mcpTool);
+    }
+
+    this.lastToolNames = mcpTools.map((t) => t.name).sort();
+    return { ...this.tools };
+  }
+
+  /**
+   * Poll the MCP server for tool list changes and invoke onUpdate when the set changes.
+   */
+  watchTools(
+    client: MCPClient,
+    onUpdate: (tools: Record<string, MastraTool>) => void,
+    intervalMs = 5_000,
+  ): void {
+    this.stopWatching();
+
+    this.watchInterval = setInterval(async () => {
+      try {
+        const mcpTools = await client.listTools();
+        const currentNames = mcpTools.map((t) => t.name).sort();
+
+        if (JSON.stringify(currentNames) !== JSON.stringify(this.lastToolNames)) {
+          this.tools = {};
+          for (const mcpTool of mcpTools) {
+            this.tools[mcpTool.name] = this.wrapTool(client, mcpTool);
+          }
+          this.lastToolNames = currentNames;
+          onUpdate({ ...this.tools });
+        }
+      } catch {
+        // Polling errors are non-fatal; next interval will retry
+      }
+    }, intervalMs);
+  }
+
+  /**
+   * Stop watching for tool changes and clean up internal state.
+   */
+  unloadTools(): void {
+    this.stopWatching();
+    this.tools = {};
+    this.lastToolNames = [];
+  }
+
+  /**
+   * Get the currently loaded tools.
+   */
+  getTools(): Record<string, MastraTool> {
+    return { ...this.tools };
+  }
+
+  private stopWatching(): void {
+    if (this.watchInterval) {
+      clearInterval(this.watchInterval);
+      this.watchInterval = null;
+    }
+  }
+
+  private wrapTool(client: MCPClient, mcpTool: MCPToolDefinition): MastraTool {
+    const inputSchema = mcpTool.inputSchema
+      ? jsonSchemaToZod(mcpTool.inputSchema)
+      : z.object({});
+
+    return createTool({
+      id: `mcp_${mcpTool.name}`,
+      description: mcpTool.description ?? `MCP tool: ${mcpTool.name}`,
+      inputSchema,
+      execute: async (inputData) => {
+        const result = await client.callTool(mcpTool.name, inputData as Record<string, unknown>);
+        return result;
+      },
+    }) as MastraTool;
+  }
+}

--- a/specs/active/SPEC-20260223-mcp-client.md
+++ b/specs/active/SPEC-20260223-mcp-client.md
@@ -1,0 +1,52 @@
+# SPEC-20260223: MCP Client SDK
+
+**Status:** CODE
+**Issue:** AGE-9
+**Branch:** feat/AGE-9-mcp-native
+**Created:** 2026-02-23
+
+## Summary
+Implement a full MCP (Model Context Protocol) client SDK with stdio, HTTP, and SSE transports, enabling AgentForge agents to connect to any MCP-compliant server and invoke tools, read resources, and use prompts.
+
+## Requirements
+
+### Core Module (packages/core/src/mcp/)
+1. **mcp-client.ts** — MCP Client with transport abstraction
+   - MCPTransportConfig: Zod-validated discriminated union (stdio/http/sse)
+   - MCPTransport interface: connect(), disconnect(), send(), onNotification(), isConnected()
+   - StdioTransport: spawns child process, communicates via JSON-RPC over stdin/stdout
+   - HttpTransport: stateless HTTP POST with timeout and abort support
+   - SSETransport: Server-Sent Events with auto-reconnect, configurable intervals/max attempts
+   - MCPClient class: lifecycle (connect/disconnect), protocol methods, event system
+   - Protocol methods: listTools(), callTool(), listResources(), readResource(), listPrompts(), getPrompt()
+   - JSON-RPC 2.0 message format with request IDs via crypto.randomUUID()
+   - MCP initialize handshake with protocol version negotiation
+   - Event emission: connected, disconnected, error, toolsChanged, resourcesChanged
+
+2. **index.ts** — Barrel re-exports for MCPClient, transports, types, schemas
+
+### Protocol Compliance
+- MCP protocol version: 2024-11-05
+- JSON-RPC 2.0 request/response format
+- Notification handling for tools/list_changed and resources/list_changed
+- Client capabilities negotiation (tools, resources, prompts)
+
+### Security Requirements
+- Validate all transport configs via Zod schemas
+- Enforce request timeouts (default 30s)
+- SSE reconnect limits to prevent infinite loops
+
+## Test Plan
+- Zod schema validation for all three transport configs (valid + invalid)
+- MCPClient.connect() / disconnect() lifecycle
+- listTools() returns MCPToolDefinition array
+- callTool() sends correct JSON-RPC method and params
+- listResources(), readResource(), listPrompts(), getPrompt()
+- Error handling: connection refused, protocol error, timeout
+- Event system: subscribe, unsubscribe, error swallowing
+- ≥40 total test cases
+
+## Non-Goals
+- MCP server implementation (already exists in mcp-server.ts)
+- Resource subscriptions — future work
+- Sampling/completion protocol extensions — future work

--- a/specs/active/SPEC-20260223-mcp-dynamic-tools.md
+++ b/specs/active/SPEC-20260223-mcp-dynamic-tools.md
@@ -1,0 +1,49 @@
+# SPEC-20260223: MCP Dynamic Tool Loading
+
+**Status:** CODE
+**Issue:** AGE-80
+**Branch:** feat/AGE-9-mcp-native
+**Created:** 2026-02-23
+
+## Summary
+Implement MCPDynamicToolLoader that wraps MCP server tools as Mastra-compatible tools, enabling hot-reload of tools from any MCP server into AgentForge agents at runtime.
+
+## Requirements
+
+### Core Module (packages/core/src/mcp/)
+1. **mcp-dynamic-tools.ts** — Dynamic tool loading and wrapping
+   - MCPDynamicToolLoader class
+   - loadTools(client: MCPClient): loads all tools from MCP server, wraps as Mastra tools
+   - watchTools(client, onUpdate, intervalMs): polls for tool list changes, invokes callback on change
+   - unloadTools(): stops watching and clears all loaded tools
+   - getTools(): returns copy of currently loaded tools
+   - jsonSchemaToZod(): converts JSON Schema to Zod schema for input validation
+   - Tool wrapping: each MCP tool gets id (mcp_{name}), description, inputSchema, execute function
+   - execute delegates to MCPClient.callTool() with the tool name and validated input
+
+2. **index.ts** — Add MCPDynamicToolLoader export
+
+### Mastra Integration
+- Import createTool from "@mastra/core/tools"
+- Each wrapped tool is a valid Mastra Tool compatible with Agent.tools
+- Input validation via Zod schemas derived from MCP tool inputSchema
+
+### Hot-Reload
+- watchTools polls at configurable interval (default 5s)
+- Detects added, removed, and changed tools by comparing sorted name lists
+- Non-fatal polling errors (silently retries on next interval)
+
+## Test Plan
+- jsonSchemaToZod conversion for all JSON Schema types
+- loadTools() wraps each MCP tool correctly
+- Tool execute delegates to callTool with correct args
+- watchTools() detects added/removed tools
+- watchTools() does not fire when tools unchanged
+- unloadTools() clears state and stops polling
+- Error propagation from callTool
+- ≥25 total test cases
+
+## Non-Goals
+- Tool caching/persistence — future work
+- Per-tool authentication — future work
+- Tool versioning — future work


### PR DESCRIPTION
## Summary

- **MCPClient** with stdio + HTTP/SSE transports, full MCP protocol compliance (initialize handshake, JSON-RPC 2.0)
- **MCPDynamicToolLoader**: wraps MCP server tools as Mastra agent tools via `createTool` from `@mastra/core/tools`
- **Hot-reload**: `watchTools()` polls for tool list changes, invokes callback on add/remove
- **SpecSafe specs** + **64 tests** (41 client + 23 dynamic tools), all passing
- Re-exported from `packages/core/src/index.ts`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 512 tests pass (64 new MCP tests)
- [ ] Manual: connect MCPClient to a real MCP server via stdio
- [ ] Manual: verify MCPDynamicToolLoader wraps tools for Mastra Agent

Closes AGE-9, AGE-80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP client SDK for connecting to MCP servers via stdio/HTTP/SSE transports
  * Dynamic tool loader to expose and hot-reload MCP server tools as runtime tools
  * JSON Schema → Zod conversion utility for tool input validation

* **Tests**
  * Extensive unit tests covering client transports, protocol flows, dynamic loader, and schema conversion

* **Documentation**
  * New SPEC documents describing MCP client and dynamic tools behavior and test plans
<!-- end of auto-generated comment: release notes by coderabbit.ai -->