### PR TITLE
feat(channels): WhatsApp Cloud API + Slack Bolt.js channel adapters (AGE-97, AGE-49)

### DIFF
--- a/packages/channels-slack/package.json
+++ b/packages/channels-slack/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@agentforge-ai/channels-slack",
+  "version": "0.6.0",
+  "description": "Slack channel adapter for AgentForge",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@slack/bolt": "^4.1.0",
+    "@slack/web-api": "^7.8.0",
+    "zod": "^3.22.0"
+  },
+  "peerDependencies": {
+    "@agentforge-ai/core": ">=0.5.0"
+  },
+  "devDependencies": {
+    "@agentforge-ai/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "slack",
+    "channels",
+    "agentforge"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Agentic-Engineering-Agency/agentforge.git",
+    "directory": "packages/channels-slack"
+  }
+}

--- a/packages/channels-slack/src/index.ts
+++ b/packages/channels-slack/src/index.ts
@@ -1,0 +1,3 @@
+export { SlackAdapter } from './slack-adapter.js';
+export { SlackChannel, startSlackChannel } from './slack-channel.js';
+export * from './types.js';

--- a/packages/channels-slack/src/slack-adapter.test.ts
+++ b/packages/channels-slack/src/slack-adapter.test.ts
@@ -1,0 +1,667 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SlackAdapter } from './slack-adapter.js';
+import { slackConfigSchema } from './types.js';
+import type { ChannelConfig } from '@agentforge-ai/core';
+
+// =====================================================
+// Mock @slack/bolt
+// =====================================================
+
+const mockPostMessage = vi.fn().mockResolvedValue({ ok: true, ts: '1234567890.123456' });
+const mockChatDelete = vi.fn().mockResolvedValue({ ok: true });
+const mockChatUpdate = vi.fn().mockResolvedValue({ ok: true, ts: '1234567890.123456' });
+const mockReactionsAdd = vi.fn().mockResolvedValue({ ok: true });
+const mockAuthTest = vi.fn().mockResolvedValue({ ok: true, user: 'testbot', team: 'TestTeam' });
+const mockAppStart = vi.fn().mockResolvedValue(undefined);
+const mockAppStop = vi.fn().mockResolvedValue(undefined);
+const mockAppMessage = vi.fn();
+const mockAppEvent = vi.fn();
+const mockAppCommand = vi.fn();
+
+vi.mock('@slack/bolt', () => ({
+  App: vi.fn().mockImplementation(() => ({
+    client: {
+      chat: {
+        postMessage: mockPostMessage,
+        delete: mockChatDelete,
+        update: mockChatUpdate,
+      },
+      reactions: { add: mockReactionsAdd },
+      auth: { test: mockAuthTest },
+    },
+    start: mockAppStart,
+    stop: mockAppStop,
+    message: mockAppMessage,
+    event: mockAppEvent,
+    command: mockAppCommand,
+  })),
+}));
+
+// =====================================================
+// Helpers
+// =====================================================
+
+function makeConfig(overrides: Partial<ChannelConfig['credentials']> = {}): ChannelConfig {
+  return {
+    id: 'test-slack',
+    platform: 'slack',
+    orgId: 'org-1',
+    agentId: 'agent-1',
+    enabled: true,
+    credentials: {
+      botToken: 'xoxb-test-token-1234',
+      appToken: 'xapp-test-token-5678',
+      signingSecret: 'test-signing-secret-abcdef',
+      ...overrides,
+    },
+    settings: { socketMode: true, port: 3099 },
+  };
+}
+
+// =====================================================
+// Tests
+// =====================================================
+
+describe('SlackAdapter', () => {
+  let adapter: SlackAdapter;
+
+  beforeEach(() => {
+    adapter = new SlackAdapter();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    try {
+      await adapter.stop();
+    } catch {
+      // ignore
+    }
+  });
+
+  // ----- Config Validation (Zod) -----
+
+  describe('Config validation (Zod)', () => {
+    it('should reject missing bot token', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: '',
+        appToken: 'xapp-valid',
+        signingSecret: 'secret',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject bot token without xoxb- prefix', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'invalid-token',
+        appToken: 'xapp-valid',
+        signingSecret: 'secret',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('xoxb-');
+      }
+    });
+
+    it('should reject missing app token', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'xoxb-valid',
+        appToken: '',
+        signingSecret: 'secret',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject app token without xapp- prefix', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'xoxb-valid',
+        appToken: 'bad-prefix',
+        signingSecret: 'secret',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject missing signing secret', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'xoxb-valid',
+        appToken: 'xapp-valid',
+        signingSecret: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept valid config with all fields', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'xoxb-valid-token',
+        appToken: 'xapp-valid-token',
+        signingSecret: 'signing-secret-123',
+        socketMode: true,
+        port: 3002,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should apply defaults for optional fields', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'xoxb-valid-token',
+        appToken: 'xapp-valid-token',
+        signingSecret: 'signing-secret-123',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.socketMode).toBe(true);
+        expect(result.data.port).toBe(3002);
+      }
+    });
+
+    it('should reject invalid port number', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'xoxb-valid-token',
+        appToken: 'xapp-valid-token',
+        signingSecret: 'secret',
+        port: 99999,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject port = 0', () => {
+      const result = slackConfigSchema.safeParse({
+        botToken: 'xoxb-valid-token',
+        appToken: 'xapp-valid-token',
+        signingSecret: 'secret',
+        port: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ----- Adapter Lifecycle -----
+
+  describe('Lifecycle (start/stop)', () => {
+    it('should start successfully with valid config', async () => {
+      await adapter.start(makeConfig());
+      expect(mockAppStart).toHaveBeenCalledOnce();
+      expect(adapter.getConnectionState()).toBe('connected');
+    });
+
+    it('should stop successfully after start', async () => {
+      await adapter.start(makeConfig());
+      await adapter.stop();
+      expect(mockAppStop).toHaveBeenCalledOnce();
+      expect(adapter.getConnectionState()).toBe('disconnected');
+    });
+
+    it('should throw on invalid credentials', async () => {
+      const config = makeConfig({ botToken: 'invalid' });
+      config.autoReconnect = false;
+      await expect(adapter.start(config)).rejects.toThrow('Invalid Slack config');
+    });
+
+    it('should register message handler on connect', async () => {
+      await adapter.start(makeConfig());
+      expect(mockAppMessage).toHaveBeenCalledOnce();
+    });
+
+    it('should register app_mention handler on connect', async () => {
+      await adapter.start(makeConfig());
+      expect(mockAppEvent).toHaveBeenCalledWith('app_mention', expect.any(Function));
+    });
+
+    it('should report platform as slack', () => {
+      expect(adapter.platform).toBe('slack');
+    });
+  });
+
+  // ----- sendMessage -----
+
+  describe('sendMessage()', () => {
+    beforeEach(async () => {
+      await adapter.start(makeConfig());
+    });
+
+    it('should send text message with correct payload', async () => {
+      const result = await adapter.sendMessage({
+        chatId: 'C123',
+        text: 'Hello Slack!',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.platformMessageId).toBe('1234567890.123456');
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C123',
+          text: 'Hello Slack!',
+        })
+      );
+    });
+
+    it('should include thread_ts for threaded messages', async () => {
+      await adapter.sendMessage({
+        chatId: 'C123',
+        text: 'Thread reply',
+        threadId: '1234567890.000001',
+      });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thread_ts: '1234567890.000001',
+        })
+      );
+    });
+
+    it('should enable markdown by default', async () => {
+      await adapter.sendMessage({
+        chatId: 'C123',
+        text: '*bold text*',
+      });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ mrkdwn: true })
+      );
+    });
+
+    it('should handle send failure gracefully', async () => {
+      mockPostMessage.mockRejectedValueOnce(new Error('channel_not_found'));
+
+      const result = await adapter.sendMessage({
+        chatId: 'invalid-channel',
+        text: 'test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('channel_not_found');
+    });
+
+    it('should return error when not connected', async () => {
+      await adapter.stop();
+
+      const result = await adapter.sendMessage({
+        chatId: 'C123',
+        text: 'test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not connected');
+    });
+  });
+
+  // ----- sendBlocks -----
+
+  describe('sendBlocks()', () => {
+    beforeEach(async () => {
+      await adapter.start(makeConfig());
+    });
+
+    it('should send Block Kit blocks with text fallback', async () => {
+      const blocks = [
+        {
+          type: 'section' as const,
+          text: { type: 'mrkdwn' as const, text: 'Hello from *Block Kit*!' },
+        },
+        { type: 'divider' as const },
+        {
+          type: 'actions' as const,
+          elements: [
+            {
+              type: 'button' as const,
+              text: { type: 'plain_text' as const, text: 'Click Me' },
+              action_id: 'btn_1',
+              value: 'clicked',
+            },
+          ],
+        },
+      ];
+
+      const result = await adapter.sendBlocks('C123', blocks, 'Fallback text');
+
+      expect(result.success).toBe(true);
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C123',
+          blocks: expect.arrayContaining([
+            expect.objectContaining({ type: 'section' }),
+            expect.objectContaining({ type: 'divider' }),
+            expect.objectContaining({ type: 'actions' }),
+          ]),
+          text: 'Fallback text',
+        })
+      );
+    });
+
+    it('should return error when not connected', async () => {
+      await adapter.stop();
+
+      const result = await adapter.sendBlocks('C123', []);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ----- app_mention event -----
+
+  describe('app_mention event', () => {
+    it('should call custom mention handler', async () => {
+      const mentionHandler = vi.fn();
+      adapter.onMention(mentionHandler);
+
+      await adapter.start(makeConfig());
+
+      // Get the registered app_mention handler
+      const eventCall = mockAppEvent.mock.calls.find((c: any[]) => c[0] === 'app_mention');
+      expect(eventCall).toBeDefined();
+
+      // Simulate app_mention event
+      const handler = eventCall![1];
+      await handler({
+        event: {
+          channel: 'C123',
+          user: 'U456',
+          text: '<@BOT> hello',
+          ts: '1234567890.123456',
+        },
+      });
+
+      expect(mentionHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C123',
+          user: 'U456',
+          text: '<@BOT> hello',
+        })
+      );
+    });
+  });
+
+  // ----- Slash Commands -----
+
+  describe('Slash command handling', () => {
+    it('should register and execute slash command handler', async () => {
+      const handler = vi.fn();
+      adapter.onSlashCommand('/test', handler);
+
+      await adapter.start(makeConfig());
+
+      // Verify command was registered
+      expect(mockAppCommand).toHaveBeenCalledWith('/test', expect.any(Function));
+    });
+  });
+
+  // ----- Rate Limiting -----
+
+  describe('Rate limiting', () => {
+    beforeEach(async () => {
+      await adapter.start(makeConfig());
+    });
+
+    it('should allow messages under rate limit', async () => {
+      const results = await Promise.all([
+        adapter.sendMessage({ chatId: 'C1', text: 'msg1' }),
+        adapter.sendMessage({ chatId: 'C1', text: 'msg2' }),
+        adapter.sendMessage({ chatId: 'C1', text: 'msg3' }),
+      ]);
+
+      results.forEach((r) => expect(r.success).toBe(true));
+    });
+
+    it('should throttle rapid sends', async () => {
+      const startTime = Date.now();
+      const promises: Promise<any>[] = [];
+
+      // Send more than a few messages rapidly
+      for (let i = 0; i < 5; i++) {
+        promises.push(adapter.sendMessage({ chatId: 'C1', text: `msg${i}` }));
+      }
+
+      const results = await Promise.all(promises);
+      results.forEach((r) => expect(r.success).toBe(true));
+      // All should eventually succeed (rate limiter queues, doesn't reject)
+      expect(mockPostMessage).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  // ----- Signature Verification -----
+
+  describe('Signature verification (HMAC-SHA256)', () => {
+    const signingSecret = 'test-signing-secret';
+
+    it('should verify a valid signature', async () => {
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const body = '{"test":"payload"}';
+      const sigBaseString = `v0:${timestamp}:${body}`;
+
+      // Compute expected signature using crypto.subtle
+      const encoder = new TextEncoder();
+      const key = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(signingSecret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+      );
+      const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(sigBaseString));
+      const hex = Array.from(new Uint8Array(sig))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      const signature = `v0=${hex}`;
+
+      const result = await SlackAdapter.verifySignature(signingSecret, body, timestamp, signature);
+      expect(result).toBe(true);
+    });
+
+    it('should reject an invalid signature', async () => {
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const body = '{"test":"payload"}';
+      const signature = 'v0=invalid_hex_signature_here_that_is_wrong';
+
+      const result = await SlackAdapter.verifySignature(signingSecret, body, timestamp, signature);
+      expect(result).toBe(false);
+    });
+
+    it('should reject expired timestamp (>5 min old)', async () => {
+      const oldTimestamp = (Math.floor(Date.now() / 1000) - 400).toString();
+      const body = '{"test":"payload"}';
+      const signature = 'v0=doesntmatter';
+
+      const result = await SlackAdapter.verifySignature(signingSecret, body, oldTimestamp, signature);
+      expect(result).toBe(false);
+    });
+
+    it('should reject future timestamp (>5 min ahead)', async () => {
+      const futureTimestamp = (Math.floor(Date.now() / 1000) + 400).toString();
+      const body = '{"test":"payload"}';
+      const signature = 'v0=doesntmatter';
+
+      const result = await SlackAdapter.verifySignature(signingSecret, body, futureTimestamp, signature);
+      expect(result).toBe(false);
+    });
+  });
+
+  // ----- deleteMessage -----
+
+  describe('deleteMessage()', () => {
+    it('should delete a message', async () => {
+      await adapter.start(makeConfig());
+
+      const result = await adapter.deleteMessage('1234567890.123456', 'C123');
+      expect(result).toBe(true);
+      expect(mockChatDelete).toHaveBeenCalledWith({
+        channel: 'C123',
+        ts: '1234567890.123456',
+      });
+    });
+
+    it('should return false when not connected', async () => {
+      const result = await adapter.deleteMessage('ts', 'C123');
+      expect(result).toBe(false);
+    });
+  });
+
+  // ----- editMessage -----
+
+  describe('editMessage()', () => {
+    it('should edit a message', async () => {
+      await adapter.start(makeConfig());
+
+      const result = await adapter.editMessage('1234567890.123456', {
+        chatId: 'C123',
+        text: 'Updated text',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockChatUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C123',
+          ts: '1234567890.123456',
+          text: 'Updated text',
+        })
+      );
+    });
+  });
+
+  // ----- addReaction -----
+
+  describe('addReaction()', () => {
+    it('should add a reaction', async () => {
+      await adapter.start(makeConfig());
+
+      const result = await adapter.addReaction('1234567890.123456', 'C123', ':thumbsup:');
+      expect(result).toBe(true);
+      expect(mockReactionsAdd).toHaveBeenCalledWith({
+        channel: 'C123',
+        timestamp: '1234567890.123456',
+        name: 'thumbsup',
+      });
+    });
+
+    it('should strip colons from emoji name', async () => {
+      await adapter.start(makeConfig());
+      await adapter.addReaction('ts', 'C123', ':rocket:');
+
+      expect(mockReactionsAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'rocket' })
+      );
+    });
+  });
+
+  // ----- healthCheck -----
+
+  describe('healthCheck()', () => {
+    it('should return healthy when connected', async () => {
+      await adapter.start(makeConfig());
+
+      const health = await adapter.healthCheck();
+      expect(health.status).toBe('healthy');
+      expect(health.details).toContain('testbot');
+    });
+
+    it('should return disconnected when not started', async () => {
+      const health = await adapter.healthCheck();
+      expect(health.status).toBe('disconnected');
+    });
+
+    it('should return unhealthy on API failure', async () => {
+      await adapter.start(makeConfig());
+      mockAuthTest.mockRejectedValueOnce(new Error('auth_failed'));
+
+      const health = await adapter.healthCheck();
+      expect(health.status).toBe('unhealthy');
+      expect(health.details).toContain('auth_failed');
+    });
+  });
+
+  // ----- getCapabilities -----
+
+  describe('getCapabilities()', () => {
+    it('should report correct capabilities', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(caps.supportsThreads).toBe(true);
+      expect(caps.supportsReactions).toBe(true);
+      expect(caps.supportsEditing).toBe(true);
+      expect(caps.supportsDeleting).toBe(true);
+      expect(caps.supportsActions).toBe(true);
+      expect(caps.supportsGroupChat).toBe(true);
+      expect(caps.supportsMarkdown).toBe(true);
+      expect(caps.maxTextLength).toBe(40000);
+      expect(caps.platformSpecific?.supportsBlockKit).toBe(true);
+      expect(caps.platformSpecific?.supportsSlashCommands).toBe(true);
+      expect(caps.platformSpecific?.supportsSocketMode).toBe(true);
+    });
+  });
+
+  // ----- Event Emission -----
+
+  describe('Event emission', () => {
+    it('should emit inbound messages to registered handlers', async () => {
+      const handler = vi.fn();
+      adapter.on(handler);
+      await adapter.start(makeConfig());
+
+      // Get the registered message handler
+      const messageHandler = mockAppMessage.mock.calls[0][0];
+
+      // Simulate incoming message
+      await messageHandler({
+        message: {
+          ts: '123.456',
+          channel: 'C123',
+          channel_type: 'im',
+          user: 'U789',
+          text: 'Hello bot!',
+        },
+        say: vi.fn(),
+      });
+
+      // Adapter emits connection_state events too, find the message event
+      const messageEvent = handler.mock.calls.find(
+        (call: any[]) => call[0].type === 'message'
+      );
+      expect(messageEvent).toBeDefined();
+      expect(messageEvent![0].data.text).toBe('Hello bot!');
+      expect(messageEvent![0].data.chatId).toBe('C123');
+    });
+
+    it('should skip bot messages', async () => {
+      const handler = vi.fn();
+      adapter.on(handler);
+      await adapter.start(makeConfig());
+
+      const messageHandler = mockAppMessage.mock.calls[0][0];
+      await messageHandler({
+        message: {
+          ts: '123.456',
+          channel: 'C123',
+          user: 'U789',
+          text: 'Bot message',
+          bot_id: 'B123',
+        },
+        say: vi.fn(),
+      });
+
+      const messageEvents = handler.mock.calls.filter(
+        (call: any[]) => call[0].type === 'message'
+      );
+      expect(messageEvents).toHaveLength(0);
+    });
+
+    it('should skip message subtypes (edits, deletes)', async () => {
+      const handler = vi.fn();
+      adapter.on(handler);
+      await adapter.start(makeConfig());
+
+      const messageHandler = mockAppMessage.mock.calls[0][0];
+      await messageHandler({
+        message: {
+          ts: '123.456',
+          channel: 'C123',
+          user: 'U789',
+          text: 'Edited',
+          subtype: 'message_changed',
+        },
+        say: vi.fn(),
+      });
+
+      const messageEvents = handler.mock.calls.filter(
+        (call: any[]) => call[0].type === 'message'
+      );
+      expect(messageEvents).toHaveLength(0);
+    });
+  });
+});

--- a/packages/channels-slack/src/slack-adapter.ts
+++ b/packages/channels-slack/src/slack-adapter.ts
@@ -1,0 +1,461 @@
+/**
+ * Slack Channel Adapter for AgentForge.
+ *
+ * Implements the ChannelAdapter interface using Slack Bolt.js with
+ * Socket Mode and Events API support.
+ *
+ * Features:
+ * - Socket Mode (WebSocket) and HTTP Events API
+ * - Block Kit rich messages
+ * - Slash command handling
+ * - app_mention event handling
+ * - Signature verification (HMAC-SHA256 via crypto.subtle)
+ * - Rate limiting with queue and delay
+ * - Zod config validation
+ *
+ * @packageDocumentation
+ */
+
+import { App } from '@slack/bolt';
+import {
+  ChannelAdapter,
+  MessageNormalizer,
+  type ChannelConfig,
+  type ChannelCapabilities,
+  type HealthStatus,
+  type OutboundMessage,
+  type SendResult,
+  type ChatType,
+} from '@agentforge-ai/core';
+import { slackConfigSchema, type SlackConfig, type SlackBlock } from './types.js';
+
+// =====================================================
+// Slack Adapter
+// =====================================================
+
+export class SlackAdapter extends ChannelAdapter {
+  readonly platform = 'slack';
+
+  private app: App | null = null;
+  private slackConfig: SlackConfig | null = null;
+
+  // Rate limiting
+  private messageTimestamps: number[] = [];
+  private readonly rateLimitPerSecond: number = 50; // Slack tier 3 limit
+  private sendQueue: Array<{ fn: () => Promise<void>; resolve: () => void; reject: (e: Error) => void }> = [];
+  private processingQueue = false;
+
+  // Event handlers registered by consumers
+  private mentionHandler: ((event: { channel: string; user: string; text: string; ts: string; thread_ts?: string }) => void | Promise<void>) | null = null;
+  private slashCommandHandlers: Map<string, (payload: { channel_id: string; user_id: string; text: string; trigger_id: string }) => void | Promise<void>> = new Map();
+
+  // ----- Lifecycle -----
+
+  async connect(config: ChannelConfig): Promise<void> {
+    const parsed = slackConfigSchema.safeParse({
+      botToken: config.credentials.botToken,
+      appToken: config.credentials.appToken,
+      signingSecret: config.credentials.signingSecret,
+      socketMode: config.settings?.socketMode ?? true,
+      port: config.settings?.port ?? 3002,
+    });
+
+    if (!parsed.success) {
+      const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      throw new Error(`Invalid Slack config: ${issues}`);
+    }
+
+    this.slackConfig = parsed.data;
+
+    this.app = new App({
+      token: this.slackConfig.botToken,
+      appToken: this.slackConfig.appToken,
+      signingSecret: this.slackConfig.signingSecret,
+      socketMode: this.slackConfig.socketMode,
+      port: this.slackConfig.port,
+    });
+
+    // Wire up message events
+    this.app.message(async ({ message, say }) => {
+      // Skip bot messages and subtypes (edits, deletes, etc.)
+      const msg = message as any;
+      if (msg.bot_id || msg.subtype) return;
+
+      const normalized = MessageNormalizer.normalize({
+        platformMessageId: msg.ts,
+        channelId: this.config?.id || '',
+        platform: 'slack',
+        chatId: msg.channel,
+        chatType: this.getChatType(msg.channel_type),
+        senderId: msg.user || '',
+        text: msg.text || '',
+        threadId: msg.thread_ts,
+        rawData: msg,
+        timestamp: new Date(parseFloat(msg.ts) * 1000),
+      });
+
+      this.emitMessage(normalized);
+    });
+
+    // Wire up app_mention events
+    this.app.event('app_mention', async ({ event }) => {
+      const normalized = MessageNormalizer.normalize({
+        platformMessageId: event.ts,
+        channelId: this.config?.id || '',
+        platform: 'slack',
+        chatId: event.channel,
+        chatType: 'channel',
+        senderId: event.user || '',
+        text: event.text || '',
+        threadId: (event as any).thread_ts,
+        rawData: event as unknown as Record<string, unknown>,
+        timestamp: new Date(parseFloat(event.ts) * 1000),
+      });
+
+      this.emitMessage(normalized);
+
+      if (this.mentionHandler) {
+        await this.mentionHandler({
+          channel: event.channel,
+          user: event.user || '',
+          text: event.text || '',
+          ts: event.ts,
+          thread_ts: (event as any).thread_ts,
+        });
+      }
+    });
+
+    // Register any deferred slash commands
+    for (const [command, handler] of this.slashCommandHandlers) {
+      this.app.command(command, async ({ command: cmd, ack }) => {
+        await ack();
+        await handler({
+          channel_id: cmd.channel_id,
+          user_id: cmd.user_id,
+          text: cmd.text,
+          trigger_id: cmd.trigger_id,
+        });
+      });
+    }
+
+    await this.app.start();
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.app) {
+      await this.app.stop();
+      this.app = null;
+    }
+    this.slackConfig = null;
+    this.sendQueue = [];
+    this.messageTimestamps = [];
+  }
+
+  // ----- Message Sending -----
+
+  async sendMessage(message: OutboundMessage): Promise<SendResult> {
+    if (!this.app) {
+      return { success: false, error: 'Slack app not connected' };
+    }
+
+    try {
+      await this.enqueueRateLimited(async () => {
+        // noop — actual send below
+      });
+
+      const result = await this.app.client.chat.postMessage({
+        channel: message.chatId,
+        text: message.text || '',
+        thread_ts: message.threadId,
+        mrkdwn: message.markdown ?? true,
+      });
+
+      return {
+        success: result.ok ?? false,
+        platformMessageId: result.ts,
+        deliveredAt: new Date(),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Send a message with Block Kit blocks.
+   */
+  async sendBlocks(channelId: string, blocks: SlackBlock[], text?: string): Promise<SendResult> {
+    if (!this.app) {
+      return { success: false, error: 'Slack app not connected' };
+    }
+
+    try {
+      await this.enforceRateLimit();
+
+      const result = await this.app.client.chat.postMessage({
+        channel: channelId,
+        blocks: blocks as any[],
+        text: text || '',
+      });
+
+      return {
+        success: result.ok ?? false,
+        platformMessageId: result.ts,
+        deliveredAt: new Date(),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // ----- Delete Message -----
+
+  override async deleteMessage(platformMessageId: string, chatId: string): Promise<boolean> {
+    if (!this.app) return false;
+
+    try {
+      const result = await this.app.client.chat.delete({
+        channel: chatId,
+        ts: platformMessageId,
+      });
+      return result.ok ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  // ----- Capabilities -----
+
+  getCapabilities(): ChannelCapabilities {
+    return {
+      supportedMedia: ['image', 'audio', 'video', 'file'],
+      maxTextLength: 40000,
+      supportsThreads: true,
+      supportsReactions: true,
+      supportsEditing: true,
+      supportsDeleting: true,
+      supportsTypingIndicator: false,
+      supportsReadReceipts: false,
+      supportsActions: true,
+      supportsGroupChat: true,
+      supportsMarkdown: true,
+      maxFileSize: 1024 * 1024 * 1024, // 1GB
+      platformSpecific: {
+        supportsBlockKit: true,
+        supportsSlashCommands: true,
+        supportsSocketMode: true,
+        supportsAppMention: true,
+        supportsThreadReplies: true,
+      },
+    };
+  }
+
+  // ----- Health Check -----
+
+  async healthCheck(): Promise<{ status: HealthStatus; details?: string }> {
+    if (!this.app) {
+      return { status: 'disconnected', details: 'Slack app not initialized' };
+    }
+
+    try {
+      const result = await this.app.client.auth.test();
+      if (result.ok) {
+        return {
+          status: 'healthy',
+          details: `Slack bot: @${result.user} in ${result.team}`,
+        };
+      }
+      return { status: 'degraded', details: `auth.test returned ok=false` };
+    } catch (error) {
+      return {
+        status: 'unhealthy',
+        details: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // ----- Optional Overrides -----
+
+  override async editMessage(
+    platformMessageId: string,
+    message: Partial<OutboundMessage>
+  ): Promise<SendResult> {
+    if (!this.app) {
+      return { success: false, error: 'Slack app not connected' };
+    }
+
+    try {
+      const result = await this.app.client.chat.update({
+        channel: message.chatId || '',
+        ts: platformMessageId,
+        text: message.text || '',
+      });
+
+      return {
+        success: result.ok ?? false,
+        platformMessageId: result.ts,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  override async addReaction(
+    platformMessageId: string,
+    chatId: string,
+    emoji: string
+  ): Promise<boolean> {
+    if (!this.app) return false;
+
+    try {
+      const result = await this.app.client.reactions.add({
+        channel: chatId,
+        timestamp: platformMessageId,
+        name: emoji.replace(/:/g, ''),
+      });
+      return result.ok ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  // ----- Slash Command Registration -----
+
+  onSlashCommand(
+    command: string,
+    handler: (payload: { channel_id: string; user_id: string; text: string; trigger_id: string }) => void | Promise<void>
+  ): void {
+    this.slashCommandHandlers.set(command, handler);
+
+    if (this.app) {
+      this.app.command(command, async ({ command: cmd, ack }) => {
+        await ack();
+        await handler({
+          channel_id: cmd.channel_id,
+          user_id: cmd.user_id,
+          text: cmd.text,
+          trigger_id: cmd.trigger_id,
+        });
+      });
+    }
+  }
+
+  // ----- Mention Handler Registration -----
+
+  onMention(
+    handler: (event: { channel: string; user: string; text: string; ts: string; thread_ts?: string }) => void | Promise<void>
+  ): void {
+    this.mentionHandler = handler;
+  }
+
+  // ----- Signature Verification -----
+
+  /**
+   * Verify Slack request signature using HMAC-SHA256 via crypto.subtle.
+   * Used for HTTP Events API mode (not needed for Socket Mode).
+   */
+  static async verifySignature(
+    signingSecret: string,
+    body: string,
+    timestamp: string,
+    signature: string
+  ): Promise<boolean> {
+    // Check timestamp freshness (5 min window)
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - parseInt(timestamp, 10)) > 300) {
+      return false;
+    }
+
+    const encoder = new TextEncoder();
+    const sigBaseString = `v0:${timestamp}:${body}`;
+
+    const key = await crypto.subtle.importKey(
+      'raw',
+      encoder.encode(signingSecret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign']
+    );
+
+    const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(sigBaseString));
+    const computedHex = `v0=${Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, '0')).join('')}`;
+
+    // Constant-time comparison
+    const computedBytes = encoder.encode(computedHex);
+    const expectedBytes = encoder.encode(signature);
+
+    if (computedBytes.length !== expectedBytes.length) return false;
+
+    let diff = 0;
+    for (let i = 0; i < computedBytes.length; i++) {
+      diff |= computedBytes[i] ^ expectedBytes[i];
+    }
+    return diff === 0;
+  }
+
+  // ----- Internal: Rate Limiting -----
+
+  private async enforceRateLimit(): Promise<void> {
+    const now = Date.now();
+    this.messageTimestamps = this.messageTimestamps.filter((t) => now - t < 1000);
+
+    if (this.messageTimestamps.length >= this.rateLimitPerSecond) {
+      const oldestInWindow = this.messageTimestamps[0];
+      const waitMs = 1000 - (now - oldestInWindow);
+      if (waitMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
+      }
+    }
+
+    this.messageTimestamps.push(Date.now());
+  }
+
+  private async enqueueRateLimited(fn: () => Promise<void>): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.sendQueue.push({ fn, resolve, reject });
+      this.processQueue();
+    });
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processingQueue) return;
+    this.processingQueue = true;
+
+    while (this.sendQueue.length > 0) {
+      const item = this.sendQueue.shift()!;
+      try {
+        await this.enforceRateLimit();
+        await item.fn();
+        item.resolve();
+      } catch (error) {
+        item.reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+
+    this.processingQueue = false;
+  }
+
+  // ----- Internal: Chat Type Mapping -----
+
+  private getChatType(channelType?: string): ChatType {
+    switch (channelType) {
+      case 'im':
+        return 'dm';
+      case 'mpim':
+        return 'group';
+      case 'channel':
+      case 'group':
+        return 'channel';
+      default:
+        return 'channel';
+    }
+  }
+}

--- a/packages/channels-slack/src/slack-channel.ts
+++ b/packages/channels-slack/src/slack-channel.ts
@@ -1,0 +1,458 @@
+/**
+ * Slack Channel for AgentForge.
+ *
+ * Bridges the SlackAdapter with the AgentForge Convex chat pipeline.
+ * This module:
+ * - Starts the Slack bot (Socket Mode or Events API)
+ * - Routes incoming messages through the agent execution pipeline
+ * - Creates/reuses Convex threads per Slack channel+user
+ * - Stores all messages in the Convex messages table
+ * - Sends agent responses back to the Slack user
+ *
+ * @packageDocumentation
+ */
+
+import { SlackAdapter } from './slack-adapter.js';
+import type {
+  ChannelConfig,
+  InboundMessage,
+  ChannelEvent,
+} from '@agentforge-ai/core';
+
+// =====================================================
+// Types
+// =====================================================
+
+export interface SlackChannelConfig {
+  /** Slack Bot Token (xoxb-...) */
+  botToken: string;
+  /** Slack App-Level Token (xapp-...) for Socket Mode */
+  appToken: string;
+  /** Slack Signing Secret */
+  signingSecret: string;
+  /** Agent ID to route messages to */
+  agentId: string;
+  /** Convex deployment URL */
+  convexUrl: string;
+  /** Whether to use Socket Mode (default: true) */
+  socketMode?: boolean;
+  /** HTTP port for Events API mode (default: 3002) */
+  port?: number;
+  /** User ID for Convex operations (default: 'slack') */
+  userId?: string;
+  /** Log level: 'debug' | 'info' | 'warn' | 'error' (default: 'info') */
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
+}
+
+type ThreadMap = Map<string, string>;
+
+interface Logger {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+// =====================================================
+// Logger
+// =====================================================
+
+const LOG_LEVELS: Record<string, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function createLogger(level: string = 'info'): Logger {
+  const threshold = LOG_LEVELS[level] ?? 1;
+  const prefix = '[agentforge:slack]';
+
+  return {
+    debug: (...args: unknown[]) => {
+      if (threshold <= 0) console.log(`${prefix} [DEBUG]`, ...args);
+    },
+    info: (...args: unknown[]) => {
+      if (threshold <= 1) console.log(`${prefix}`, ...args);
+    },
+    warn: (...args: unknown[]) => {
+      if (threshold <= 2) console.warn(`${prefix} [WARN]`, ...args);
+    },
+    error: (...args: unknown[]) => {
+      if (threshold <= 3) console.error(`${prefix} [ERROR]`, ...args);
+    },
+  };
+}
+
+// =====================================================
+// Convex HTTP Client
+// =====================================================
+
+class ConvexHttpApi {
+  private baseUrl: string;
+
+  constructor(deploymentUrl: string) {
+    this.baseUrl = deploymentUrl.replace(/\/$/, '');
+  }
+
+  async query(functionPath: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const response = await fetch(`${this.baseUrl}/api/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: functionPath, args }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Convex query ${functionPath} failed: ${response.status} ${text}`);
+    }
+    const data = await response.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') throw new Error(`Convex query ${functionPath} error: ${data.errorMessage}`);
+    return data.value;
+  }
+
+  async mutation(functionPath: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const response = await fetch(`${this.baseUrl}/api/mutation`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: functionPath, args }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Convex mutation ${functionPath} failed: ${response.status} ${text}`);
+    }
+    const data = await response.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') throw new Error(`Convex mutation ${functionPath} error: ${data.errorMessage}`);
+    return data.value;
+  }
+
+  async action(functionPath: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const response = await fetch(`${this.baseUrl}/api/action`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: functionPath, args }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Convex action ${functionPath} failed: ${response.status} ${text}`);
+    }
+    const data = await response.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') throw new Error(`Convex action ${functionPath} error: ${data.errorMessage}`);
+    return data.value;
+  }
+}
+
+// =====================================================
+// Slack Channel Runner
+// =====================================================
+
+export class SlackChannel {
+  private adapter: SlackAdapter;
+  private convex: ConvexHttpApi;
+  private config: SlackChannelConfig;
+  private threadMap: ThreadMap = new Map();
+  private logger: Logger;
+  private processingMessages: Set<string> = new Set();
+  private isRunning: boolean = false;
+
+  constructor(config: SlackChannelConfig) {
+    this.config = config;
+    this.adapter = new SlackAdapter();
+    this.convex = new ConvexHttpApi(config.convexUrl);
+    this.logger = createLogger(config.logLevel);
+  }
+
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn('Slack channel is already running');
+      return;
+    }
+
+    this.logger.info('Starting Slack channel...');
+    this.logger.info(`Agent ID: ${this.config.agentId}`);
+    this.logger.info(`Convex URL: ${this.config.convexUrl}`);
+    this.logger.info(`Mode: ${this.config.socketMode !== false ? 'Socket Mode' : 'Events API'}`);
+
+    // Verify the agent exists
+    try {
+      const agent = await this.convex.query('agents:get', { id: this.config.agentId });
+      if (!agent) {
+        throw new Error(
+          `Agent "${this.config.agentId}" not found in Convex. ` +
+          `Create it first with: agentforge agents create`
+        );
+      }
+      const agentData = agent as { name: string; model: string; provider: string };
+      this.logger.info(`Agent: ${agentData.name} (${agentData.model} via ${agentData.provider})`);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        throw error;
+      }
+      this.logger.warn('Could not verify agent (Convex may be unreachable). Continuing...');
+    }
+
+    // Wire up event handler
+    this.adapter.on(this.handleEvent.bind(this));
+
+    const channelConfig: ChannelConfig = {
+      id: `slack-${this.config.agentId}`,
+      platform: 'slack',
+      orgId: 'default',
+      agentId: this.config.agentId,
+      enabled: true,
+      credentials: {
+        botToken: this.config.botToken,
+        appToken: this.config.appToken,
+        signingSecret: this.config.signingSecret,
+      },
+      settings: {
+        socketMode: this.config.socketMode ?? true,
+        port: this.config.port ?? 3002,
+      },
+      autoReconnect: true,
+      reconnectIntervalMs: 5000,
+      maxReconnectAttempts: 20,
+    };
+
+    await this.adapter.start(channelConfig);
+    this.isRunning = true;
+
+    this.logger.info('Slack channel started successfully!');
+    this.logger.info('Bot is listening for messages...');
+  }
+
+  async stop(): Promise<void> {
+    if (!this.isRunning) return;
+
+    this.logger.info('Stopping Slack channel...');
+    await this.adapter.stop();
+    this.isRunning = false;
+    this.threadMap.clear();
+    this.processingMessages.clear();
+    this.logger.info('Slack channel stopped.');
+  }
+
+  getThreadMap(): ReadonlyMap<string, string> {
+    return this.threadMap;
+  }
+
+  getAdapter(): SlackAdapter {
+    return this.adapter;
+  }
+
+  get running(): boolean {
+    return this.isRunning;
+  }
+
+  // ----- Internal: Event Handling -----
+
+  private async handleEvent(event: ChannelEvent): Promise<void> {
+    switch (event.type) {
+      case 'message':
+        await this.handleInboundMessage(event.data as InboundMessage);
+        break;
+      case 'connection_state':
+        this.logger.debug('Connection state:', (event.data as { state: string }).state);
+        break;
+      case 'error':
+        this.logger.error('Adapter error:', (event.data as { error: Error }).error.message);
+        break;
+      default:
+        this.logger.debug('Unhandled event type:', event.type);
+    }
+  }
+
+  private async handleInboundMessage(message: InboundMessage): Promise<void> {
+    if (!message.text?.trim()) {
+      this.logger.debug('Skipping empty message');
+      return;
+    }
+
+    // Dedup
+    const dedupKey = `${message.chatId}:${message.platformMessageId}`;
+    if (this.processingMessages.has(dedupKey)) {
+      this.logger.debug('Skipping duplicate message:', dedupKey);
+      return;
+    }
+    this.processingMessages.add(dedupKey);
+
+    const senderName = message.sender.displayName || message.sender.username || 'Unknown';
+    this.logger.info(`Message from ${senderName} (channel ${message.chatId}): ${message.text}`);
+
+    try {
+      await this.routeToAgent(message);
+    } catch (error) {
+      this.logger.error('Error handling message:', error);
+      try {
+        await this.adapter.sendMessage({
+          chatId: message.chatId,
+          text: 'Sorry, I encountered an error processing your message. Please try again.',
+          threadId: message.threadId,
+        });
+      } catch {
+        this.logger.error('Failed to send error message to user');
+      }
+    } finally {
+      setTimeout(() => {
+        this.processingMessages.delete(dedupKey);
+      }, 30000);
+    }
+  }
+
+  // ----- Internal: Agent Routing -----
+
+  private async routeToAgent(message: InboundMessage): Promise<void> {
+    const threadKey = `${message.chatId}:${message.sender.platformUserId}`;
+    const threadId = await this.getOrCreateThread(threadKey, message.sender.displayName);
+    const userId = this.config.userId || `slack:${message.sender.platformUserId}`;
+
+    this.logger.debug(`Sending to agent ${this.config.agentId}, thread ${threadId}`);
+
+    const result = await this.convex.action('chat:sendMessage', {
+      agentId: this.config.agentId,
+      threadId,
+      content: message.text!,
+      userId,
+    }) as { success: boolean; response: string; usage?: { totalTokens: number } };
+
+    if (result?.response) {
+      const chunks = this.splitMessage(result.response, 4000);
+      for (const chunk of chunks) {
+        await this.adapter.sendMessage({
+          chatId: message.chatId,
+          text: chunk,
+          threadId: message.threadId,
+        });
+      }
+
+      if (result.usage) {
+        this.logger.debug(`Tokens used: ${result.usage.totalTokens}`);
+      }
+    } else {
+      await this.adapter.sendMessage({
+        chatId: message.chatId,
+        text: "I received your message but couldn't generate a response. Please try again.",
+        threadId: message.threadId,
+      });
+    }
+  }
+
+  // ----- Internal: Thread Management -----
+
+  private async getOrCreateThread(threadKey: string, senderName?: string): Promise<string> {
+    const cached = this.threadMap.get(threadKey);
+    if (cached) return cached;
+
+    const threadName = senderName
+      ? `Slack: ${senderName}`
+      : `Slack ${threadKey}`;
+
+    const userId = this.config.userId || `slack:${threadKey}`;
+
+    const threadId = await this.convex.mutation('chat:createThread', {
+      agentId: this.config.agentId,
+      name: threadName,
+      userId,
+    }) as string;
+
+    this.threadMap.set(threadKey, threadId);
+    this.logger.info(`Created new thread ${threadId} for ${threadKey}`);
+
+    return threadId;
+  }
+
+  // ----- Internal: Utilities -----
+
+  private splitMessage(text: string, maxLength: number): string[] {
+    if (text.length <= maxLength) return [text];
+
+    const chunks: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > 0) {
+      if (remaining.length <= maxLength) {
+        chunks.push(remaining);
+        break;
+      }
+
+      let splitIdx = remaining.lastIndexOf('\n\n', maxLength);
+      if (splitIdx === -1 || splitIdx < maxLength / 2) {
+        splitIdx = remaining.lastIndexOf('\n', maxLength);
+      }
+      if (splitIdx === -1 || splitIdx < maxLength / 2) {
+        splitIdx = remaining.lastIndexOf(' ', maxLength);
+      }
+      if (splitIdx === -1 || splitIdx < maxLength / 2) {
+        splitIdx = maxLength;
+      }
+
+      chunks.push(remaining.substring(0, splitIdx));
+      remaining = remaining.substring(splitIdx).trimStart();
+    }
+
+    return chunks;
+  }
+}
+
+// =====================================================
+// Convenience Factory
+// =====================================================
+
+export async function startSlackChannel(
+  overrides: Partial<SlackChannelConfig> = {}
+): Promise<SlackChannel> {
+  const botToken = overrides.botToken || process.env.SLACK_BOT_TOKEN;
+  const appToken = overrides.appToken || process.env.SLACK_APP_TOKEN;
+  const signingSecret = overrides.signingSecret || process.env.SLACK_SIGNING_SECRET;
+  const convexUrl = overrides.convexUrl || process.env.CONVEX_URL;
+  const agentId = overrides.agentId || process.env.AGENTFORGE_AGENT_ID;
+
+  if (!botToken) {
+    throw new Error(
+      'SLACK_BOT_TOKEN is required. Set it in your .env file or pass it as botToken in the config.'
+    );
+  }
+  if (!appToken) {
+    throw new Error(
+      'SLACK_APP_TOKEN is required for Socket Mode. Set it in your .env file or pass it as appToken in the config.'
+    );
+  }
+  if (!signingSecret) {
+    throw new Error(
+      'SLACK_SIGNING_SECRET is required. Set it in your .env file or pass it as signingSecret in the config.'
+    );
+  }
+  if (!convexUrl) {
+    throw new Error(
+      'CONVEX_URL is required. Set it in your .env file or pass it as convexUrl in the config.'
+    );
+  }
+  if (!agentId) {
+    throw new Error(
+      'Agent ID is required. Pass it as agentId in the config or set AGENTFORGE_AGENT_ID env var.'
+    );
+  }
+
+  const channel = new SlackChannel({
+    botToken,
+    appToken,
+    signingSecret,
+    convexUrl,
+    agentId,
+    socketMode: overrides.socketMode,
+    port: overrides.port,
+    userId: overrides.userId,
+    logLevel: overrides.logLevel,
+  });
+
+  const shutdown = async () => {
+    console.log('\nShutting down Slack channel...');
+    await channel.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  await channel.start();
+  return channel;
+}

--- a/packages/channels-slack/src/types.ts
+++ b/packages/channels-slack/src/types.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod';
+
+// =====================================================
+// Slack Configuration
+// =====================================================
+
+export const slackConfigSchema = z.object({
+  botToken: z.string().min(1, 'Bot token is required').startsWith('xoxb-', 'Bot token must start with xoxb-'),
+  appToken: z.string().min(1, 'App token is required').startsWith('xapp-', 'App token must start with xapp-'),
+  signingSecret: z.string().min(1, 'Signing secret is required'),
+  socketMode: z.boolean().default(true),
+  port: z.number().int().min(1).max(65535).default(3002),
+});
+
+export type SlackConfig = z.infer<typeof slackConfigSchema>;
+
+// =====================================================
+// Slack Message Types
+// =====================================================
+
+export interface SlackMessage {
+  type: string;
+  subtype?: string;
+  channel: string;
+  user: string;
+  text: string;
+  ts: string;
+  thread_ts?: string;
+  bot_id?: string;
+  blocks?: SlackBlock[];
+  files?: SlackFile[];
+}
+
+export interface SlackFile {
+  id: string;
+  name: string;
+  mimetype: string;
+  url_private: string;
+  size: number;
+}
+
+// =====================================================
+// Slack Event Types
+// =====================================================
+
+export interface SlackEvent {
+  type: string;
+  event_ts: string;
+  user?: string;
+  channel?: string;
+  text?: string;
+  ts?: string;
+  thread_ts?: string;
+  bot_id?: string;
+  subtype?: string;
+  command?: string;
+}
+
+// =====================================================
+// Slack Block Kit Types
+// =====================================================
+
+export type SlackBlock =
+  | SlackSectionBlock
+  | SlackDividerBlock
+  | SlackActionsBlock
+  | SlackHeaderBlock
+  | SlackContextBlock
+  | SlackImageBlock;
+
+export interface SlackSectionBlock {
+  type: 'section';
+  text?: SlackTextObject;
+  fields?: SlackTextObject[];
+  accessory?: SlackBlockElement;
+  block_id?: string;
+}
+
+export interface SlackDividerBlock {
+  type: 'divider';
+  block_id?: string;
+}
+
+export interface SlackActionsBlock {
+  type: 'actions';
+  elements: SlackBlockElement[];
+  block_id?: string;
+}
+
+export interface SlackHeaderBlock {
+  type: 'header';
+  text: SlackTextObject;
+  block_id?: string;
+}
+
+export interface SlackContextBlock {
+  type: 'context';
+  elements: (SlackTextObject | SlackImageElement)[];
+  block_id?: string;
+}
+
+export interface SlackImageBlock {
+  type: 'image';
+  image_url: string;
+  alt_text: string;
+  title?: SlackTextObject;
+  block_id?: string;
+}
+
+export interface SlackTextObject {
+  type: 'plain_text' | 'mrkdwn';
+  text: string;
+  emoji?: boolean;
+}
+
+export type SlackBlockElement =
+  | SlackButtonElement
+  | SlackImageElement
+  | SlackOverflowElement;
+
+export interface SlackButtonElement {
+  type: 'button';
+  text: SlackTextObject;
+  action_id: string;
+  value?: string;
+  url?: string;
+  style?: 'primary' | 'danger';
+}
+
+export interface SlackImageElement {
+  type: 'image';
+  image_url: string;
+  alt_text: string;
+}
+
+export interface SlackOverflowElement {
+  type: 'overflow';
+  action_id: string;
+  options: Array<{
+    text: SlackTextObject;
+    value: string;
+  }>;
+}

--- a/packages/channels-slack/tsconfig.json
+++ b/packages/channels-slack/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/channels-slack/tsup.config.ts
+++ b/packages/channels-slack/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'node18',
+  external: ['@agentforge-ai/core', '@slack/bolt', '@slack/web-api'],
+});

--- a/packages/channels-slack/vitest.config.ts
+++ b/packages/channels-slack/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/packages/cli/src/commands/channel-slack.ts
+++ b/packages/cli/src/commands/channel-slack.ts
@@ -1,0 +1,731 @@
+/**
+ * CLI Command: agentforge channel:slack
+ *
+ * Configure and start a Slack bot that routes messages through
+ * the AgentForge agent execution pipeline via Slack Bolt.js.
+ *
+ * Usage:
+ *   agentforge channel:slack start --agent <id> [--bot-token <token>]
+ *   agentforge channel:slack configure
+ *   agentforge channel:slack status
+ */
+
+import { Command } from 'commander';
+import { createClient, safeCall } from '../lib/convex-client.js';
+import { header, success, error, info, dim, warn, details, colors } from '../lib/display.js';
+import fs from 'fs-extra';
+import path from 'node:path';
+import readline from 'node:readline';
+
+function prompt(q: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((r) => rl.question(q, (a) => { rl.close(); r(a.trim()); }));
+}
+
+/**
+ * Read a value from .env files in the current directory.
+ */
+function readEnvValue(key: string): string | undefined {
+  const cwd = process.cwd();
+  const envFiles = ['.env.local', '.env', '.env.production'];
+  for (const envFile of envFiles) {
+    const envPath = path.join(cwd, envFile);
+    if (fs.existsSync(envPath)) {
+      const content = fs.readFileSync(envPath, 'utf-8');
+      const match = content.match(new RegExp(`^${key}=(.+)$`, 'm'));
+      if (match) return match[1].trim().replace(/["']/g, '');
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Write a value to .env.local in the current directory.
+ */
+function writeEnvValue(key: string, value: string, envFile: string = '.env.local'): void {
+  const envPath = path.join(process.cwd(), envFile);
+  let content = '';
+  if (fs.existsSync(envPath)) {
+    content = fs.readFileSync(envPath, 'utf-8');
+  }
+
+  const lines = content.split('\n');
+  const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+  if (idx >= 0) {
+    lines[idx] = `${key}=${value}`;
+  } else {
+    lines.push(`${key}=${value}`);
+  }
+
+  fs.writeFileSync(envPath, lines.join('\n'));
+}
+
+export function registerChannelSlackCommand(program: Command) {
+  const channel = program
+    .command('channel:slack')
+    .description('Manage the Slack messaging channel');
+
+  // ─── Start ─────────────────────────────────────────────────────────
+  channel
+    .command('start')
+    .description('Start the Slack bot and begin routing messages to an agent')
+    .option('-a, --agent <id>', 'Agent ID to route messages to')
+    .option('--bot-token <token>', 'Slack bot token (xoxb-...) (overrides .env)')
+    .option('--app-token <token>', 'Slack app-level token (xapp-...) for socket mode (overrides .env)')
+    .option('--signing-secret <secret>', 'Slack signing secret (overrides .env)')
+    .option('--socket-mode', 'Enable socket mode (default: true)', true)
+    .option('--log-level <level>', 'Log level: debug, info, warn, error', 'info')
+    .action(async (opts) => {
+      header('Slack Channel');
+
+      // Resolve bot token
+      const botToken = opts.botToken || readEnvValue('SLACK_BOT_TOKEN') || process.env.SLACK_BOT_TOKEN;
+      if (!botToken) {
+        error('Slack Bot Token not found.');
+        info('Set it with: agentforge channel:slack configure');
+        info('Or pass it with: --bot-token <token>');
+        info('Or set SLACK_BOT_TOKEN in your .env.local file');
+        process.exit(1);
+      }
+
+      // Resolve app token (required for socket mode)
+      const appToken = opts.appToken || readEnvValue('SLACK_APP_TOKEN') || process.env.SLACK_APP_TOKEN;
+      if (opts.socketMode && !appToken) {
+        error('Slack App Token not found (required for socket mode).');
+        info('Set it with: agentforge channel:slack configure');
+        info('Or pass it with: --app-token <token>');
+        info('Or set SLACK_APP_TOKEN in your .env.local file');
+        info('Or disable socket mode with: --no-socket-mode');
+        process.exit(1);
+      }
+
+      // Resolve signing secret
+      const signingSecret = opts.signingSecret || readEnvValue('SLACK_SIGNING_SECRET') || process.env.SLACK_SIGNING_SECRET;
+      if (!signingSecret) {
+        error('Slack Signing Secret not found.');
+        info('Set it with: agentforge channel:slack configure');
+        info('Or pass it with: --signing-secret <secret>');
+        info('Or set SLACK_SIGNING_SECRET in your .env.local file');
+        process.exit(1);
+      }
+
+      // Resolve Convex URL
+      const convexUrl = readEnvValue('CONVEX_URL') || process.env.CONVEX_URL;
+      if (!convexUrl) {
+        error('CONVEX_URL not found. Run `npx convex dev` first.');
+        process.exit(1);
+      }
+
+      // Resolve agent ID
+      let agentId = opts.agent;
+      if (!agentId) {
+        agentId = readEnvValue('AGENTFORGE_AGENT_ID') || process.env.AGENTFORGE_AGENT_ID;
+      }
+
+      if (!agentId) {
+        // List agents and let user pick
+        info('No agent specified. Fetching available agents...');
+        const client = await createClient();
+        const agents = await safeCall(
+          () => client.query('agents:list' as any, {}),
+          'Failed to list agents'
+        );
+
+        if (!agents || (agents as any[]).length === 0) {
+          error('No agents found. Create one first: agentforge agents create');
+          process.exit(1);
+        }
+
+        console.log();
+        (agents as any[]).forEach((a: any, i: number) => {
+          console.log(
+            `  ${colors.cyan}${i + 1}.${colors.reset} ${a.name} ${colors.dim}(${a.id})${colors.reset} — ${a.model}`
+          );
+        });
+        console.log();
+
+        const choice = await prompt('Select agent (number or ID): ');
+        const idx = parseInt(choice) - 1;
+        agentId = idx >= 0 && idx < (agents as any[]).length
+          ? (agents as any[])[idx].id
+          : choice;
+      }
+
+      // Display configuration
+      info(`Agent:       ${agentId}`);
+      info(`Convex:      ${convexUrl}`);
+      info(`Mode:        ${opts.socketMode ? 'Socket Mode' : 'Events API'}`);
+      info(`Log:         ${opts.logLevel}`);
+      console.log();
+
+      // Dynamically import the SlackChannel from channels-slack
+      let startSlackChannel: any;
+      try {
+        const slackPkg = '@agentforge-ai/channels-slack';
+        const mod = await import(/* @vite-ignore */ slackPkg);
+        startSlackChannel = mod.startSlackChannel;
+      } catch (importError: any) {
+        // Fallback: use the built-in minimal runner
+        error('Could not import @agentforge-ai/channels-slack. Using built-in Slack runner.');
+        dim(`  Error: ${importError.message}`);
+        console.log();
+
+        await runMinimalSlackBot({
+          botToken,
+          appToken: appToken || '',
+          signingSecret,
+          agentId,
+          convexUrl,
+          socketMode: opts.socketMode,
+          logLevel: opts.logLevel,
+        });
+        return;
+      }
+
+      // Start the Slack channel
+      try {
+        await startSlackChannel({
+          botToken,
+          appToken,
+          signingSecret,
+          agentId,
+          convexUrl,
+          socketMode: opts.socketMode,
+          logLevel: opts.logLevel,
+        });
+
+        success('Slack bot is running!');
+        dim('  Press Ctrl+C to stop.');
+
+        // Keep the process alive
+        await new Promise(() => {});
+      } catch (startError: any) {
+        error(`Failed to start Slack bot: ${startError.message}`);
+        process.exit(1);
+      }
+    });
+
+  // ─── Configure ─────────────────────────────────────────────────────
+  channel
+    .command('configure')
+    .description('Configure the Slack bot credentials and settings')
+    .action(async () => {
+      header('Configure Slack Channel');
+
+      console.log();
+      info('To set up a Slack app:');
+      dim('  1. Go to https://api.slack.com/apps and create a new app');
+      dim('  2. Enable Socket Mode under Settings > Socket Mode');
+      dim('  3. Add bot scopes: chat:write, im:history, im:read, channels:history');
+      dim('  4. Install the app to your workspace');
+      dim('  5. Copy the Bot Token, App-Level Token, and Signing Secret');
+      console.log();
+
+      // Bot Token
+      const currentBotToken = readEnvValue('SLACK_BOT_TOKEN');
+      if (currentBotToken) {
+        const masked = currentBotToken.slice(0, 8) + '****' + currentBotToken.slice(-4);
+        info(`Current bot token: ${masked}`);
+      }
+
+      const botToken = await prompt('Slack Bot Token (xoxb-...): ');
+      if (!botToken) {
+        error('Bot token is required.');
+        process.exit(1);
+      }
+
+      if (!botToken.startsWith('xoxb-')) {
+        warn('Bot token should start with "xoxb-". Please verify this is correct.');
+      }
+
+      // Validate the bot token via auth.test
+      info('Validating bot token...');
+      try {
+        const response = await fetch('https://slack.com/api/auth.test', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${botToken}`,
+            'Content-Type': 'application/json',
+          },
+        });
+        const data = await response.json() as {
+          ok: boolean;
+          team?: string;
+          user?: string;
+          bot_id?: string;
+          error?: string;
+        };
+        if (!data.ok) {
+          warn(`Token validation warning: ${data.error}`);
+          info('Saving token anyway. You can validate later with: agentforge channel:slack status');
+        } else {
+          success(`Bot verified: @${data.user} in workspace "${data.team}"`);
+        }
+      } catch (fetchError: any) {
+        warn(`Could not validate token (network error): ${fetchError.message}`);
+        info('Saving token anyway.');
+      }
+
+      writeEnvValue('SLACK_BOT_TOKEN', botToken);
+      success('Bot token saved to .env.local');
+
+      // App Token
+      console.log();
+      const currentAppToken = readEnvValue('SLACK_APP_TOKEN');
+      if (currentAppToken) {
+        const masked = currentAppToken.slice(0, 8) + '****' + currentAppToken.slice(-4);
+        info(`Current app token: ${masked}`);
+      }
+
+      const appToken = await prompt('Slack App-Level Token (xapp-..., for socket mode): ');
+      if (!appToken) {
+        warn('App-level token not provided. Socket mode will not be available.');
+      } else {
+        if (!appToken.startsWith('xapp-')) {
+          warn('App token should start with "xapp-". Please verify this is correct.');
+        }
+        writeEnvValue('SLACK_APP_TOKEN', appToken);
+        success('App token saved to .env.local');
+      }
+
+      // Signing Secret
+      console.log();
+      const currentSigningSecret = readEnvValue('SLACK_SIGNING_SECRET');
+      if (currentSigningSecret) {
+        info(`Current signing secret: ${currentSigningSecret.slice(0, 6)}****`);
+      }
+
+      const signingSecret = await prompt('Slack Signing Secret: ');
+      if (!signingSecret) {
+        error('Signing secret is required.');
+        process.exit(1);
+      }
+
+      if (signingSecret.length < 20) {
+        warn('Signing secret looks too short. Please verify this is correct.');
+      }
+
+      writeEnvValue('SLACK_SIGNING_SECRET', signingSecret);
+      success('Signing secret saved to .env.local');
+
+      // Default agent
+      console.log();
+      const defaultAgent = await prompt('Default agent ID (optional, press Enter to skip): ');
+      if (defaultAgent) {
+        writeEnvValue('AGENTFORGE_AGENT_ID', defaultAgent);
+        success(`Default agent set to: ${defaultAgent}`);
+      }
+
+      console.log();
+      success('Configuration complete!');
+      info('Start the bot with: agentforge channel:slack start');
+    });
+
+  // ─── Status ────────────────────────────────────────────────────────
+  channel
+    .command('status')
+    .description('Check the Slack bot configuration and connectivity')
+    .action(async () => {
+      header('Slack Channel Status');
+
+      const botToken = readEnvValue('SLACK_BOT_TOKEN');
+      const appToken = readEnvValue('SLACK_APP_TOKEN');
+      const signingSecret = readEnvValue('SLACK_SIGNING_SECRET');
+      const agentId = readEnvValue('AGENTFORGE_AGENT_ID');
+      const convexUrl = readEnvValue('CONVEX_URL');
+
+      const statusData: Record<string, string> = {
+        'Bot Token': botToken ? `${botToken.slice(0, 8)}****${botToken.slice(-4)}` : `${colors.red}Not configured${colors.reset}`,
+        'App Token': appToken ? `${appToken.slice(0, 8)}****${appToken.slice(-4)}` : `${colors.dim}Not set${colors.reset}`,
+        'Signing Secret': signingSecret ? `${signingSecret.slice(0, 6)}****` : `${colors.red}Not configured${colors.reset}`,
+        'Default Agent': agentId || `${colors.dim}Not set${colors.reset}`,
+        'Convex URL': convexUrl || `${colors.red}Not configured${colors.reset}`,
+      };
+
+      details(statusData);
+
+      // Validate bot token if present
+      if (botToken) {
+        info('Checking Slack API connectivity...');
+        try {
+          const response = await fetch('https://slack.com/api/auth.test', {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${botToken}`,
+              'Content-Type': 'application/json',
+            },
+          });
+          const data = await response.json() as {
+            ok: boolean;
+            team?: string;
+            user?: string;
+            team_id?: string;
+            bot_id?: string;
+            error?: string;
+          };
+          if (data.ok) {
+            success(`Slack API connected: @${data.user} in workspace "${data.team}" (${data.team_id})`);
+          } else {
+            error(`Slack API error: ${data.error}`);
+          }
+        } catch {
+          warn('Could not reach Slack API (network error).');
+        }
+      }
+
+      // Check Convex connectivity
+      if (convexUrl) {
+        info('Checking Convex connectivity...');
+        try {
+          const client = await createClient();
+          const agents = await client.query('agents:list' as any, {});
+          success(`Convex connected. ${(agents as any[]).length} agents available.`);
+        } catch {
+          warn('Could not reach Convex deployment.');
+        }
+      }
+    });
+}
+
+// =====================================================
+// Minimal Built-in Slack Bot Runner
+// =====================================================
+
+/**
+ * A minimal Slack bot runner that works without the @agentforge-ai/channels-slack
+ * package. Uses the Slack Web API and Convex HTTP API directly.
+ *
+ * This is a fallback for when the channels-slack package isn't available
+ * (e.g., in a fresh project before building).
+ *
+ * Uses Socket Mode via the Slack Events API if an app token is provided,
+ * otherwise falls back to a basic HTTP server for the Events API.
+ */
+export async function runMinimalSlackBot(config: {
+  botToken: string;
+  appToken: string;
+  signingSecret: string;
+  agentId: string;
+  convexUrl: string;
+  socketMode?: boolean;
+  logLevel?: string;
+}): Promise<void> {
+  const { botToken, appToken, signingSecret, agentId, convexUrl } = config;
+  const convexBase = convexUrl.replace(/\/$/, '');
+  const threadMap = new Map<string, string>();
+
+  // Verify bot token
+  info('Verifying Slack bot token...');
+  try {
+    const res = await fetch('https://slack.com/api/auth.test', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    const data = await res.json() as { ok: boolean; team?: string; user?: string; error?: string };
+    if (!data.ok) {
+      error(`Slack auth error: ${data.error}`);
+      process.exit(1);
+    }
+    success(`Slack bot connected: @${data.user} in "${data.team}"`);
+  } catch (fetchError: any) {
+    warn(`Could not verify bot token: ${fetchError.message}`);
+    info('Continuing anyway...');
+  }
+
+  // Convex HTTP helpers
+  async function convexMutation(fn: string, args: Record<string, unknown>): Promise<unknown> {
+    const res = await fetch(`${convexBase}/api/mutation`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: fn, args }),
+    });
+    const data = await res.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') throw new Error(data.errorMessage);
+    return data.value;
+  }
+
+  async function convexAction(fn: string, args: Record<string, unknown>): Promise<unknown> {
+    const res = await fetch(`${convexBase}/api/action`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: fn, args }),
+    });
+    const data = await res.json() as { value?: unknown; status?: string; errorMessage?: string };
+    if (data.status === 'error') throw new Error(data.errorMessage);
+    return data.value;
+  }
+
+  async function sendSlackMessage(channel: string, text: string, threadTs?: string): Promise<void> {
+    const body: Record<string, unknown> = { channel, text };
+    if (threadTs) body.thread_ts = threadTs;
+
+    await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function getOrCreateThread(channelThreadKey: string, senderName?: string): Promise<string> {
+    const cached = threadMap.get(channelThreadKey);
+    if (cached) return cached;
+
+    const threadId = await convexMutation('chat:createThread', {
+      agentId,
+      name: senderName ? `Slack: ${senderName}` : `Slack ${channelThreadKey}`,
+      userId: `slack:${channelThreadKey}`,
+    }) as string;
+
+    threadMap.set(channelThreadKey, threadId);
+    return threadId;
+  }
+
+  async function handleSlackMessage(event: any): Promise<void> {
+    if (event.bot_id || event.subtype) return;
+
+    const channelId = event.channel;
+    const userId = event.user;
+    const text = (event.text || '').trim();
+    const threadTs = event.thread_ts || event.ts;
+
+    if (!text) return;
+
+    const threadKey = `${channelId}:${userId}`;
+    console.log(`[Slack:${channelId}] ${text}`);
+
+    try {
+      const convexThreadId = await getOrCreateThread(threadKey, `slack:${userId}`);
+      const result = await convexAction('chat:sendMessage', {
+        agentId,
+        threadId: convexThreadId,
+        content: text,
+        userId: `slack:${userId}`,
+      }) as { response: string };
+
+      if (result?.response) {
+        const response = result.response;
+        // Split long messages at 4000 chars (Slack's limit)
+        if (response.length <= 4000) {
+          await sendSlackMessage(channelId, response, threadTs);
+        } else {
+          const chunks = response.match(/.{1,4000}/gs) || [];
+          for (const chunk of chunks) {
+            await sendSlackMessage(channelId, chunk, threadTs);
+          }
+        }
+        console.log(`[Agent] ${response.substring(0, 100)}${response.length > 100 ? '...' : ''}`);
+      } else {
+        await sendSlackMessage(channelId, "I couldn't generate a response. Please try again.", threadTs);
+      }
+    } catch (routeError: any) {
+      console.error(`Error: ${routeError.message}`);
+      await sendSlackMessage(channelId, 'Sorry, I encountered an error. Please try again.', threadTs);
+    }
+  }
+
+  // If app token is available, use Socket Mode
+  if (appToken && config.socketMode !== false) {
+    info('Starting in Socket Mode...');
+
+    try {
+      // Attempt to connect via Slack Socket Mode WebSocket
+      const wsUrlRes = await fetch('https://slack.com/api/apps.connections.open', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${appToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      const wsData = await wsUrlRes.json() as { ok: boolean; url?: string; error?: string };
+
+      if (!wsData.ok || !wsData.url) {
+        throw new Error(`Could not open WebSocket connection: ${wsData.error}`);
+      }
+
+      const { default: WebSocket } = await import('ws' as any);
+      const ws = new WebSocket(wsData.url);
+
+      ws.on('open', () => {
+        success('Socket Mode connected!');
+        dim('  Listening for messages. Press Ctrl+C to stop.');
+        console.log();
+      });
+
+      ws.on('message', async (data: Buffer) => {
+        try {
+          const payload = JSON.parse(data.toString());
+
+          // Acknowledge the event
+          if (payload.envelope_id) {
+            ws.send(JSON.stringify({ envelope_id: payload.envelope_id }));
+          }
+
+          // Handle events
+          if (payload.type === 'events_api' && payload.payload?.event) {
+            const event = payload.payload.event;
+            if (event.type === 'message') {
+              await handleSlackMessage(event);
+            }
+          }
+
+          // Handle slash commands
+          if (payload.type === 'slash_commands' && payload.payload) {
+            const slashPayload = payload.payload;
+            const command = slashPayload.command;
+            const channelId = slashPayload.channel_id;
+            const userId = slashPayload.user_id;
+            const text = slashPayload.text || '';
+
+            if (command === '/start' || command === '/new') {
+              const key = `${channelId}:${userId}`;
+              threadMap.delete(key);
+              await sendSlackMessage(channelId, 'New conversation started! Send me a message.');
+            } else if (command === '/help') {
+              await sendSlackMessage(channelId, 'AgentForge Slack Bot\n\nJust send me a message and I\'ll respond using AI.\n\nCommands:\n/start — Reset and start fresh\n/new — Start a fresh conversation\n/help — Show this help\n/ask <question> — Ask a question');
+            } else if (command === '/ask') {
+              await handleSlackMessage({ channel: channelId, user: userId, text, ts: Date.now().toString() });
+            }
+          }
+        } catch (parseError: any) {
+          console.error(`Error processing message: ${parseError.message}`);
+        }
+      });
+
+      ws.on('close', (code: number) => {
+        warn(`Socket Mode disconnected (code: ${code}). Reconnecting in 5s...`);
+        setTimeout(() => runMinimalSlackBot(config), 5000);
+      });
+
+      ws.on('error', (err: Error) => {
+        console.error(`WebSocket error: ${err.message}`);
+      });
+
+      // Graceful shutdown
+      process.on('SIGINT', () => {
+        console.log('\nStopping...');
+        ws.close();
+        process.exit(0);
+      });
+
+      // Keep alive
+      await new Promise(() => {});
+    } catch (socketError: any) {
+      warn(`Socket Mode failed: ${socketError.message}`);
+      info('Falling back to HTTP Events API server...');
+    }
+  }
+
+  // Fallback: HTTP server for Events API
+  info('Starting HTTP server for Events API...');
+  const port = 3002;
+  const path_ = '/slack/events';
+
+  const http = await import('node:http');
+  const { createHmac, timingSafeEqual } = await import('node:crypto');
+
+  function verifySlackSignature(body: string, timestamp: string, signature: string): boolean {
+    const sigBaseString = `v0:${timestamp}:${body}`;
+    const hmac = createHmac('sha256', signingSecret);
+    hmac.update(sigBaseString);
+    const computedSig = `v0=${hmac.digest('hex')}`;
+    try {
+      return timingSafeEqual(Buffer.from(computedSig), Buffer.from(signature));
+    } catch {
+      return false;
+    }
+  }
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url || '/', `http://localhost:${port}`);
+
+    if (url.pathname !== path_) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.writeHead(405);
+      res.end('Method Not Allowed');
+      return;
+    }
+
+    try {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(chunk as Buffer);
+      }
+      const rawBody = Buffer.concat(chunks).toString();
+
+      // Verify Slack signature
+      const timestamp = req.headers['x-slack-request-timestamp'] as string;
+      const signature = req.headers['x-slack-signature'] as string;
+
+      if (timestamp && signature && signingSecret) {
+        const now = Math.floor(Date.now() / 1000);
+        if (Math.abs(now - parseInt(timestamp)) > 300) {
+          res.writeHead(403);
+          res.end('Request too old');
+          return;
+        }
+
+        if (!verifySlackSignature(rawBody, timestamp, signature)) {
+          res.writeHead(403);
+          res.end('Invalid signature');
+          return;
+        }
+      }
+
+      const body = JSON.parse(rawBody);
+
+      // Handle URL verification challenge
+      if (body.type === 'url_verification') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ challenge: body.challenge }));
+        return;
+      }
+
+      // Acknowledge immediately
+      res.writeHead(200);
+      res.end('OK');
+
+      // Handle message events
+      if (body.type === 'event_callback' && body.event?.type === 'message') {
+        await handleSlackMessage(body.event);
+      }
+    } catch (parseError: any) {
+      console.error(`Parse error: ${parseError.message}`);
+      if (!res.headersSent) {
+        res.writeHead(400);
+        res.end('Bad Request');
+      }
+    }
+  });
+
+  // Graceful shutdown
+  process.on('SIGINT', () => {
+    console.log('\nStopping...');
+    server.close();
+    process.exit(0);
+  });
+
+  server.listen(port, () => {
+    success(`Events API server listening on port ${port}`);
+    info(`Events API URL: http://localhost:${port}${path_}`);
+    console.log();
+    info('Next steps:');
+    dim('  1. Expose this URL publicly (e.g., ngrok http ' + port + ')');
+    dim('  2. Configure the Events API URL in your Slack app settings');
+    dim('  3. Subscribe to the "message.im" and "message.channels" events');
+    dim('  Press Ctrl+C to stop.');
+  });
+
+  // Keep alive
+  await new Promise(() => {});
+}

--- a/packages/core/src/adapters/whatsapp-adapter.test.ts
+++ b/packages/core/src/adapters/whatsapp-adapter.test.ts
@@ -395,23 +395,23 @@ describe('WhatsAppAdapter', () => {
       await adapter.connect(createConfig({ settings: { webhookPort: 0 } }));
     });
 
-    it('should verify valid webhook request', () => {
-      const result = adapter.verifyWebhook('subscribe', 'test-verify-token', 'challenge-123');
+    it('should verify valid webhook request', async () => {
+      const result = await adapter.verifyWebhook('subscribe', 'test-verify-token', 'challenge-123');
       expect(result).toBe('challenge-123');
     });
 
-    it('should reject invalid verify token', () => {
-      const result = adapter.verifyWebhook('subscribe', 'wrong-token', 'challenge-123');
+    it('should reject invalid verify token', async () => {
+      const result = await adapter.verifyWebhook('subscribe', 'wrong-token', 'challenge-123');
       expect(result).toBeNull();
     });
 
-    it('should reject non-subscribe mode', () => {
-      const result = adapter.verifyWebhook('unsubscribe', 'test-verify-token', 'challenge-123');
+    it('should reject non-subscribe mode', async () => {
+      const result = await adapter.verifyWebhook('unsubscribe', 'test-verify-token', 'challenge-123');
       expect(result).toBeNull();
     });
 
-    it('should handle missing parameters', () => {
-      const result = adapter.verifyWebhook(undefined, undefined, undefined);
+    it('should handle missing parameters', async () => {
+      const result = await adapter.verifyWebhook(undefined, undefined, undefined);
       expect(result).toBeNull();
     });
   });

--- a/packages/core/src/adapters/whatsapp-adapter.ts
+++ b/packages/core/src/adapters/whatsapp-adapter.ts
@@ -30,6 +30,91 @@ import {
 } from '../channel-adapter.js';
 
 // =====================================================
+// WhatsApp-specific Types
+// =====================================================
+
+/**
+ * A single row inside a WhatsApp list message section.
+ */
+export interface WhatsAppListRow {
+  /** Row ID returned in callback */
+  id: string;
+  /** Row display title (max 24 chars) */
+  title: string;
+  /** Optional description (max 72 chars) */
+  description?: string;
+}
+
+/**
+ * A section inside a WhatsApp list message.
+ */
+export interface WhatsAppListSection {
+  /** Section title (max 24 chars) */
+  title?: string;
+  /** Rows within this section (max 10 per section, 10 total) */
+  rows: WhatsAppListRow[];
+}
+
+/**
+ * Parameters for sending a WhatsApp list message.
+ */
+export interface WhatsAppListMessageParams {
+  /** Target phone number */
+  to: string;
+  /** Main body text */
+  bodyText: string;
+  /** Button label that opens the list (max 20 chars) */
+  buttonText: string;
+  /** List sections */
+  sections: WhatsAppListSection[];
+  /** Optional header text */
+  headerText?: string;
+  /** Optional footer text */
+  footerText?: string;
+  /** Message to reply to */
+  replyToMessageId?: string;
+}
+
+/**
+ * A single component parameter for a WhatsApp template message.
+ */
+export interface WhatsAppTemplateParameter {
+  type: 'text' | 'currency' | 'date_time' | 'image' | 'document' | 'video';
+  text?: string;
+  currency?: { fallback_value: string; code: string; amount_1000: number };
+  date_time?: { fallback_value: string };
+  image?: { link: string };
+  document?: { link: string; filename?: string };
+  video?: { link: string };
+}
+
+/**
+ * A component block in a WhatsApp template message.
+ */
+export interface WhatsAppTemplateComponent {
+  type: 'header' | 'body' | 'button';
+  sub_type?: 'quick_reply' | 'url';
+  index?: number;
+  parameters: WhatsAppTemplateParameter[];
+}
+
+/**
+ * Parameters for sending a WhatsApp template message.
+ */
+export interface WhatsAppTemplateMessageParams {
+  /** Target phone number */
+  to: string;
+  /** Template name (as registered in Meta Business Manager) */
+  templateName: string;
+  /** Language code (e.g. 'en_US') */
+  languageCode: string;
+  /** Optional template components with variable substitutions */
+  components?: WhatsAppTemplateComponent[];
+  /** Message to reply to */
+  replyToMessageId?: string;
+}
+
+// =====================================================
 // WhatsApp Cloud API Types
 // =====================================================
 
@@ -201,6 +286,9 @@ export class WhatsAppAdapter extends ChannelAdapter {
   // Rate limiting
   private messageTimestamps: number[] = [];
   private rateLimitPerSecond: number = 80;
+
+  // Track last inbound message ID per chat for typing indicator (mark-as-read)
+  private lastInboundMessageId: Map<string, string> = new Map();
 
   // Built-in webhook server
   private httpServer: import('node:http').Server | null = null;
@@ -382,10 +470,16 @@ export class WhatsAppAdapter extends ChannelAdapter {
 
   // ----- Optional Overrides -----
 
+  /**
+   * WhatsApp has no native typing indicator, but we track the latest inbound
+   * message ID per chat so we can issue a mark-as-read when this is called,
+   * which surfaces as blue double-ticks to the user — the closest equivalent.
+   */
   override async sendTypingIndicator(chatId: string): Promise<void> {
-    // WhatsApp doesn't have a typing indicator API, but we can mark messages as read
-    // which shows the blue checkmarks. For actual typing, we do nothing.
-    void chatId;
+    const lastMsgId = this.lastInboundMessageId.get(chatId);
+    if (lastMsgId) {
+      await this.markAsRead(lastMsgId);
+    }
   }
 
   override async addReaction(
@@ -418,15 +512,21 @@ export class WhatsAppAdapter extends ChannelAdapter {
 
   /**
    * Verify a webhook GET request from Meta.
+   * Uses constant-time comparison via Web Crypto API to prevent timing attacks.
    * Returns the challenge string if verification succeeds, null otherwise.
    */
-  verifyWebhook(
+  async verifyWebhook(
     mode: string | undefined,
     token: string | undefined,
     challenge: string | undefined
-  ): string | null {
-    if (mode === 'subscribe' && token === this.verifyToken) {
-      return challenge || null;
+  ): Promise<string | null> {
+    if (mode !== 'subscribe' || !token || !challenge) {
+      return null;
+    }
+
+    const isValid = await timingSafeEqual(token, this.verifyToken);
+    if (isValid) {
+      return challenge;
     }
     return null;
   }
@@ -493,6 +593,9 @@ export class WhatsAppAdapter extends ChannelAdapter {
     contact: WhatsAppContact | undefined,
     metadata: { display_phone_number: string; phone_number_id: string }
   ): void {
+    // Track the latest message ID per chat for typing indicator support
+    this.lastInboundMessageId.set(message.from, message.id);
+
     // Handle interactive responses (button/list replies) as callbacks
     if (message.type === 'interactive' && message.interactive) {
       this.processInteractiveResponse(message, contact, metadata);
@@ -991,9 +1094,177 @@ export class WhatsAppAdapter extends ChannelAdapter {
     return data;
   }
 
+  // ----- Public: List Messages -----
+
+  /**
+   * Send a WhatsApp interactive list message.
+   * Lists can contain up to 10 sections with up to 10 rows each (10 rows total).
+   */
+  async sendListMessage(params: WhatsAppListMessageParams): Promise<SendResult> {
+    try {
+      await this.enforceRateLimit();
+
+      const interactive: Record<string, unknown> = {
+        type: 'list',
+        body: { text: params.bodyText },
+        action: {
+          button: params.buttonText.substring(0, 20),
+          sections: params.sections.map((s) => ({
+            title: s.title,
+            rows: s.rows.map((r) => ({
+              id: r.id,
+              title: r.title.substring(0, 24),
+              description: r.description?.substring(0, 72),
+            })),
+          })),
+        },
+      };
+
+      if (params.headerText) {
+        interactive.header = { type: 'text', text: params.headerText };
+      }
+
+      if (params.footerText) {
+        interactive.footer = { text: params.footerText };
+      }
+
+      const body: Record<string, unknown> = {
+        messaging_product: 'whatsapp',
+        recipient_type: 'individual',
+        to: params.to,
+        type: 'interactive',
+        interactive,
+      };
+
+      if (params.replyToMessageId) {
+        body.context = { message_id: params.replyToMessageId };
+      }
+
+      const result = await this.callApi<{ messages: Array<{ id: string }> }>(
+        `${this.phoneNumberId}/messages`,
+        'POST',
+        body
+      );
+
+      return {
+        success: true,
+        platformMessageId: result.messages?.[0]?.id,
+        deliveredAt: new Date(),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // ----- Public: Template Messages -----
+
+  /**
+   * Send a WhatsApp template message.
+   * Templates must be pre-approved in Meta Business Manager.
+   */
+  async sendTemplateMessage(params: WhatsAppTemplateMessageParams): Promise<SendResult> {
+    try {
+      await this.enforceRateLimit();
+
+      const template: Record<string, unknown> = {
+        name: params.templateName,
+        language: { code: params.languageCode },
+      };
+
+      if (params.components && params.components.length > 0) {
+        template.components = params.components;
+      }
+
+      const body: Record<string, unknown> = {
+        messaging_product: 'whatsapp',
+        recipient_type: 'individual',
+        to: params.to,
+        type: 'template',
+        template,
+      };
+
+      if (params.replyToMessageId) {
+        body.context = { message_id: params.replyToMessageId };
+      }
+
+      const result = await this.callApi<{ messages: Array<{ id: string }> }>(
+        `${this.phoneNumberId}/messages`,
+        'POST',
+        body
+      );
+
+      return {
+        success: true,
+        platformMessageId: result.messages?.[0]?.id,
+        deliveredAt: new Date(),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // ----- Public: Mark as Read -----
+
+  /**
+   * Mark a specific message as read.
+   * This shows blue double-ticks to the sender.
+   */
+  async markMessageAsRead(messageId: string): Promise<void> {
+    await this.markAsRead(messageId);
+  }
+
   // ----- Utility -----
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
+}
+
+// =====================================================
+// Utility: Constant-Time String Comparison (Web Crypto)
+// =====================================================
+
+/**
+ * Constant-time string comparison using the Web Crypto API.
+ * Prevents timing attacks on webhook token verification.
+ * Uses `crypto.subtle` — no `node:crypto` import needed.
+ */
+async function timingSafeEqual(a: string, b: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+
+  // Import both as HMAC keys and sign a fixed message — comparing the signatures
+  // ensures constant time regardless of early mismatch.
+  // Alternatively, use subtle.digest for simpler approach:
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode('webhook-verify'),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+
+  const [sigA, sigB] = await Promise.all([
+    crypto.subtle.sign('HMAC', key, aBytes),
+    crypto.subtle.sign('HMAC', key, bBytes),
+  ]);
+
+  // Compare the HMAC signatures byte-by-byte — both are same length (32 bytes)
+  const viewA = new Uint8Array(sigA);
+  const viewB = new Uint8Array(sigB);
+
+  if (viewA.length !== viewB.length) return false;
+
+  let diff = 0;
+  for (let i = 0; i < viewA.length; i++) {
+    diff |= viewA[i] ^ viewB[i];
+  }
+  return diff === 0;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,31 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@25.2.3)(terser@5.46.0)
 
+  packages/channels-slack:
+    dependencies:
+      '@slack/bolt':
+        specifier: ^4.1.0
+        version: 4.6.0(@types/express@4.17.25)
+      '@slack/web-api':
+        specifier: ^7.8.0
+        version: 7.14.1
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+    devDependencies:
+      '@agentforge-ai/core':
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@25.2.3)(terser@5.46.0)
+
   packages/cli:
     dependencies:
       chalk:
@@ -1767,6 +1792,32 @@ packages:
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
 
+  '@slack/bolt@4.6.0':
+    resolution: {integrity: sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+    peerDependencies:
+      '@types/express': ^5.0.0
+
+  '@slack/logger@4.0.0':
+    resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/oauth@3.0.4':
+    resolution: {integrity: sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+
+  '@slack/socket-mode@2.0.5':
+    resolution: {integrity: sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.20.0':
+    resolution: {integrity: sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.14.1':
+    resolution: {integrity: sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@specsafe/core@0.8.0':
     resolution: {integrity: sha512-hift70r+IlI1wyCKGDwjg0TwLIU6uhgXVRYZZi9GAp8/++/zNS8BW08bt1N1dRa6Oubgr1Bo00i7rvEGbXDvOg==}
     engines: {node: '>=18'}
@@ -1958,8 +2009,14 @@ packages:
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -1989,6 +2046,9 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
@@ -2138,12 +2198,18 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.24:
     resolution: {integrity: sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -2187,6 +2253,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2275,6 +2344,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -2383,6 +2456,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2441,6 +2518,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2476,6 +2556,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
@@ -2520,6 +2604,12 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -2588,9 +2678,22 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2689,6 +2792,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -2749,6 +2856,9 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -2779,6 +2889,10 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
@@ -2866,6 +2980,16 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -2887,6 +3011,27 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
@@ -3074,13 +3219,29 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-retry@7.1.1:
     resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
     engines: {node: '>=20'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -3219,6 +3380,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -3337,6 +3501,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3624,6 +3792,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsscmp@1.0.6:
+    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
+    engines: {node: '>=0.6.x'}
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -5178,6 +5350,71 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
+  '@slack/bolt@4.6.0(@types/express@4.17.25)':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/oauth': 3.0.4
+      '@slack/socket-mode': 2.0.5
+      '@slack/types': 2.20.0
+      '@slack/web-api': 7.14.1
+      '@types/express': 4.17.25
+      axios: 1.13.5
+      express: 5.2.1
+      path-to-regexp: 8.3.0
+      raw-body: 3.0.2
+      tsscmp: 1.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@slack/logger@4.0.0':
+    dependencies:
+      '@types/node': 22.19.11
+
+  '@slack/oauth@3.0.4':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/jsonwebtoken': 9.0.10
+      '@types/node': 22.19.11
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/socket-mode@2.0.5':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/node': 22.19.11
+      '@types/ws': 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@slack/types@2.20.0': {}
+
+  '@slack/web-api@7.14.1':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/types': 2.20.0
+      '@types/node': 22.19.11
+      '@types/retry': 0.12.0
+      axios: 1.13.5
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
   '@specsafe/core@0.8.0': {}
 
   '@specsafe/test-gen@0.8.0':
@@ -5371,7 +5608,14 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 22.19.11
+
   '@types/mime@1.3.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@18.19.130':
     dependencies:
@@ -5405,6 +5649,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/retry@0.12.0': {}
 
   '@types/send@0.17.6':
     dependencies:
@@ -5577,6 +5823,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.24(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
@@ -5585,6 +5833,14 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
+
+  axios@1.13.5:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -5659,6 +5915,8 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2:
     optional: true
@@ -5748,6 +6006,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@12.1.0: {}
 
   commander@2.20.3:
@@ -5823,6 +6085,8 @@ snapshots:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -5901,6 +6165,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.286: {}
@@ -5926,6 +6194,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -6053,6 +6328,10 @@ snapshots:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
+
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -6193,10 +6472,20 @@ snapshots:
       mlly: 1.8.0
       rollup: 4.57.1
 
+  follow-redirects@1.15.11: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -6286,6 +6575,10 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -6335,6 +6628,8 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-electron@2.2.2: {}
+
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
@@ -6352,6 +6647,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-promise@4.0.0: {}
+
+  is-stream@2.0.1: {}
 
   is-unicode-supported@1.3.0: {}
 
@@ -6430,6 +6727,30 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
@@ -6441,6 +6762,20 @@ snapshots:
   load-tsconfig@0.2.5: {}
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.snakecase@4.1.1: {}
 
@@ -6598,11 +6933,27 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
 
+  p-finally@1.0.0: {}
+
   p-map@7.0.4: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   p-retry@7.1.1:
     dependencies:
       is-network-error: 1.3.0
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   package-json-from-dist@1.0.1: {}
 
@@ -6728,6 +7079,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -6842,6 +7195,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -7204,6 +7559,8 @@ snapshots:
       typescript: 5.9.3
 
   tslib@2.8.1: {}
+
+  tsscmp@1.0.6: {}
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:

--- a/specs/active/SPEC-20260223-slack-channel.md
+++ b/specs/active/SPEC-20260223-slack-channel.md
@@ -1,0 +1,63 @@
+# SPEC-20260223-slack-channel
+
+## Title
+Slack Channel Adapter (AGE-49)
+
+## Status
+CODE
+
+## Summary
+Implement a Slack channel adapter for AgentForge using Slack Bolt.js with Socket Mode
+and Events API support. The adapter bridges Slack workspaces to the AgentForge agent
+execution pipeline, supporting Block Kit rich messages, slash commands, app_mention events,
+signature verification (HMAC-SHA256), and rate limiting.
+
+## Requirements
+
+### Functional
+- SlackAdapter class extending ChannelAdapter base class
+- Socket Mode (WebSocket) and HTTP Events API support via @slack/bolt
+- Config validation using Zod schema (botToken, appToken, signingSecret)
+- Message sending: text, Block Kit blocks, threaded replies
+- Event handling: message, app_mention, slash commands
+- Message editing and deletion
+- Emoji reactions
+- Signature verification using HMAC-SHA256 via crypto.subtle (no node:crypto)
+- Rate limiting with queue and delay (50 msg/sec tier 3 limit)
+
+### Non-Functional
+- SlackChannel class routes messages through Convex chat pipeline
+- Thread mapping: Slack channel+user → Convex threadId
+- CLI command: `agentforge channel:slack` (start, configure, status)
+- Graceful shutdown on SIGINT/SIGTERM
+
+## Architecture
+- `packages/channels-slack/src/types.ts` — TypeScript types and Zod schemas
+- `packages/channels-slack/src/slack-adapter.ts` — SlackAdapter (ChannelAdapter impl)
+- `packages/channels-slack/src/slack-channel.ts` — SlackChannel (pipeline router)
+- `packages/channels-slack/src/index.ts` — Public exports
+- `packages/cli/src/commands/channel-slack.ts` — CLI command
+
+## Test Plan
+- 45 tests in `packages/channels-slack/src/slack-adapter.test.ts`
+- Config validation: missing token, invalid prefix, defaults
+- Lifecycle: start/stop, error handling
+- sendMessage: correct payload, threading, markdown, failure
+- sendBlocks: Block Kit rendering
+- app_mention: event handler invocation
+- Slash commands: registration and execution
+- Rate limiting: throttle behavior
+- Signature verification: valid HMAC, invalid HMAC, expired timestamp
+- Delete/edit/reaction operations
+- Health check: healthy, disconnected, API failure
+- Capabilities reporting
+- Event emission: message routing, bot skip, subtype skip
+
+## Dependencies
+- @slack/bolt ^4.1.0
+- @slack/web-api ^7.8.0
+- zod ^3.22.0
+- @agentforge-ai/core (peer)
+
+## Linear Issue
+AGE-49

--- a/specs/active/SPEC-20260223-whatsapp-channel.md
+++ b/specs/active/SPEC-20260223-whatsapp-channel.md
@@ -1,0 +1,59 @@
+# SPEC-20260223-whatsapp-channel
+
+## Title
+WhatsApp Cloud API Channel Adapter (AGE-97)
+
+## Status
+CODE
+
+## Summary
+Expanded WhatsApp Cloud API adapter for AgentForge implementing the ChannelAdapter
+interface. Supports webhook-based message reception/verification, all message types
+(text, image, audio, video, document, sticker, location), interactive buttons and
+list messages, template messages, typing indicators (mark as read), rate limiting,
+and media download.
+
+## Requirements
+
+### Functional
+- WhatsAppAdapter class extending ChannelAdapter base class
+- Webhook verification (GET) with constant-time comparison via crypto.subtle
+- Webhook POST message reception and normalization
+- Text messages with preview URLs
+- Image, audio, video, document, sticker, location sending
+- Interactive button messages (up to 3 quick replies)
+- List messages with sections and rows
+- Template messages with variable substitutions
+- Mark as read (typing indicator equivalent)
+- Emoji reactions
+- Media URL retrieval and download
+- Rate limiting (80 msg/sec default)
+- Built-in HTTP webhook server
+
+### Non-Functional
+- No node:crypto dependency — uses Web Crypto API (crypto.subtle)
+- Constant-time string comparison to prevent timing attacks
+- Platform-specific types for WhatsApp Cloud API payloads
+- Status update processing (sent, delivered, read, failed)
+
+## Architecture
+- `packages/core/src/adapters/whatsapp-adapter.ts` — WhatsAppAdapter (1270 lines)
+- Extends ChannelAdapter from `packages/core/src/channel-adapter.ts`
+- Built-in HTTP server for webhook (configurable port/path)
+- Message normalization via MessageNormalizer
+
+## Test Plan
+- Integration with existing channel-adapter test suite
+- Webhook verification: valid token, invalid token, missing params
+- Message normalization: all message types
+- Media extraction: image, audio, video, document, sticker, location
+- Interactive message construction
+- Rate limiting enforcement
+- Status update processing
+
+## Dependencies
+- No external dependencies (uses native fetch + Web Crypto)
+- @agentforge-ai/core channel-adapter base class
+
+## Linear Issue
+AGE-97


### PR DESCRIPTION
## Summary

- **WhatsApp Cloud API adapter** (expanded): webhook verification via `crypto.subtle`, all message types (text, image, audio, video, document, sticker, location), interactive buttons + list messages, template messages, read receipts, rate limiting (80/s), built-in HTTP webhook server
- **New `@agentforge-ai/channels-slack` package**: Bolt.js Socket Mode + Events API, Block Kit rich messages, slash commands, `app_mention` handling, HMAC-SHA256 signature verification via `crypto.subtle` (no `node:crypto`), rate limiting with queue (50/s)
- **SlackChannel** pipeline router: routes Slack messages through Convex chat pipeline with thread mapping (channel+user → Convex thread)
- **CLI command** `agentforge channel:slack` with `start`, `configure`, and `status` subcommands
- **SpecSafe specs**: `SPEC-20260223-slack-channel.md` + `SPEC-20260223-whatsapp-channel.md`
- **42 Slack adapter tests** covering config validation, lifecycle, messaging, Block Kit, mentions, slash commands, rate limiting, signature verification, edit/delete/reactions, health checks
- **Fix**: WhatsApp `verifyWebhook` test assertions now properly `await` the async method

## Test plan
- [x] `pnpm build` passes for all packages including `@agentforge-ai/channels-slack`
- [x] `pnpm test` passes — 526 tests (448 core + 42 slack + 36 discord)
- [ ] Manual: configure Slack app credentials and run `agentforge channel:slack start`
- [ ] Manual: verify WhatsApp webhook flow end-to-end

Closes AGE-97, AGE-49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Slack workspace integration supporting message threads, slash commands, app mentions, and message editing
  * WhatsApp template and list message support, plus message read status tracking
  * Emoji reactions for Slack messages
  * Health checks and rate limiting for platform adapters
  * CLI commands for Slack workspace configuration and status monitoring

* **Documentation**
  * Added specification documents for Slack and WhatsApp channel adapters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->