### PR TITLE
fix(ci): CLI Build workflow — force-add gitignored dist/

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check for changes in dist
         id: check_changes
         run: |
-          git add packages/cli/dist/
+          git add -f packages/cli/dist/
           if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
The 'Rebuild CLI Distribution' workflow has been failing on every push to main since at least PR #83.\n\nRoot cause: `packages/cli/dist/` is in `.gitignore`, so `git add packages/cli/dist/` fails.\n\nFix: add `-f` flag to bypass .gitignore for the auto-commit step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to improve artifact handling during the package build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->