### PR TITLE
feat(web): Agentic Engineering brand palette

### DIFF
--- a/packages/web/app/routes/chat.tsx
+++ b/packages/web/app/routes/chat.tsx
@@ -273,7 +273,7 @@ function ChatPageComponent() {
                     ? "bg-orange-500"
                     : currentAgent?.provider === "openrouter"
                     ? "bg-purple-500"
-                    : "bg-blue-500"
+                    : "bg-ae-accent"
                 }`}
               />
               <select

--- a/packages/web/app/routes/files.tsx
+++ b/packages/web/app/routes/files.tsx
@@ -188,7 +188,7 @@ function FilesPage() {
                     <button onClick={(e) => { e.stopPropagation(); openRename(folder.id, folder.name, "folder"); }} className="p-1 hover:bg-accent rounded"><Edit2 className="h-3 w-3" /></button>
                     <button onClick={(e) => { e.stopPropagation(); handleDeleteFolder(folder.id); }} className="p-1 hover:bg-destructive/20 rounded text-destructive"><Trash2 className="h-3 w-3" /></button>
                   </div>
-                  <Folder className="h-10 w-10 text-blue-400 mb-2" /><p className="text-sm font-medium truncate">{folder.name}</p><p className="text-xs text-muted-foreground mt-1">{formatDate(folder.createdAt)}</p>
+                  <Folder className="h-10 w-10 text-ae-accent mb-2" /><p className="text-sm font-medium truncate">{folder.name}</p><p className="text-xs text-muted-foreground mt-1">{formatDate(folder.createdAt)}</p>
                 </div>
               ))}
               {filteredFiles.map((file: any) => { const Icon = getFileIcon(file.mimeType ?? file.type ?? ""); return (
@@ -209,7 +209,7 @@ function FilesPage() {
                 <tbody>
                   {filteredFolders.map((folder) => (
                     <tr key={folder.id} className="border-b hover:bg-accent/50 cursor-pointer" onDoubleClick={() => setCurrentFolderId(folder.id)}>
-                      <td className="px-4 py-3 flex items-center gap-2"><Folder className="h-4 w-4 text-blue-400" /><span className="font-medium">{folder.name}</span></td>
+                      <td className="px-4 py-3 flex items-center gap-2"><Folder className="h-4 w-4 text-ae-accent" /><span className="font-medium">{folder.name}</span></td>
                       <td className="px-4 py-3 text-muted-foreground">Folder</td><td className="px-4 py-3 text-muted-foreground">—</td><td className="px-4 py-3 text-muted-foreground">{formatDate(folder.createdAt)}</td>
                       <td className="px-4 py-3"><div className="flex items-center gap-1"><button onClick={() => openRename(folder.id, folder.name, "folder")} className="p-1 hover:bg-accent rounded"><Edit2 className="h-3 w-3" /></button><button onClick={() => handleDeleteFolder(folder.id)} className="p-1 hover:bg-destructive/20 rounded text-destructive"><Trash2 className="h-3 w-3" /></button></div></td>
                     </tr>

--- a/packages/web/app/routes/observability.tsx
+++ b/packages/web/app/routes/observability.tsx
@@ -150,7 +150,7 @@ function ObservabilityPage() {
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 {[
                   { label: "Total Spend", value: `$${totalSpend.toFixed(2)}`, icon: DollarSign, color: "text-green-400" },
-                  { label: "Avg Cost/Call", value: `$${avgCostPerCall.toFixed(4)}`, icon: DollarSign, color: "text-blue-400" },
+                  { label: "Avg Cost/Call", value: `$${avgCostPerCall.toFixed(4)}`, icon: DollarSign, color: "text-ae-accent" },
                   { label: "Total Tokens", value: formatTokens(totalTokens), icon: Zap, color: "text-purple-400" },
                 ].map((stat) => (
                   <div key={stat.label} className="bg-card border rounded-lg p-5">

--- a/packages/web/app/routes/runs.$runId.tsx
+++ b/packages/web/app/routes/runs.$runId.tsx
@@ -52,7 +52,7 @@ interface RunSummary {
 // ============================================================
 
 const EVENT_CONFIG: Record<EventType, { icon: typeof Brain; color: string; bgColor: string; label: string }> = {
-  llm: { icon: Brain, color: "text-blue-400", bgColor: "bg-blue-500/20", label: "LLM Call" },
+  llm: { icon: Brain, color: "text-ae-accent", bgColor: "bg-ae-accent/20", label: "LLM Call" },
   tool: { icon: Wrench, color: "text-green-400", bgColor: "bg-green-500/20", label: "Tool Call" },
   memory: { icon: Database, color: "text-purple-400", bgColor: "bg-purple-500/20", label: "Memory Op" },
   error: { icon: AlertCircle, color: "text-red-400", bgColor: "bg-red-500/20", label: "Error" },
@@ -76,7 +76,7 @@ function formatTimestamp(ts: number): string {
 function statusBadgeClass(status: RunSummary["status"]): string {
   if (status === "completed") return "px-2 py-0.5 rounded text-xs bg-green-500/20 text-green-400";
   if (status === "error") return "px-2 py-0.5 rounded text-xs bg-red-500/20 text-red-400";
-  return "px-2 py-0.5 rounded text-xs bg-blue-500/20 text-blue-400";
+  return "px-2 py-0.5 rounded text-xs bg-ae-accent/20 text-ae-accent";
 }
 
 // ============================================================
@@ -131,7 +131,7 @@ function AgentRunPage() {
         {/* Summary Cards */}
         <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
           {[
-            { label: "Duration", value: formatDuration(summary.totalDurationMs), icon: Clock, color: "text-blue-400" },
+            { label: "Duration", value: formatDuration(summary.totalDurationMs), icon: Clock, color: "text-ae-accent" },
             { label: "Cost", value: `$${summary.totalCost.toFixed(4)}`, icon: DollarSign, color: "text-green-400" },
             { label: "Model", value: summary.model, icon: Brain, color: "text-purple-400" },
             { label: "Events", value: String(summary.eventCount), icon: Activity, color: "text-orange-400" },

--- a/packages/web/app/routes/settings.tsx
+++ b/packages/web/app/routes/settings.tsx
@@ -387,7 +387,7 @@ function VaultTab() {
   };
 
   const categoryColors: Record<string, string> = {
-    api_key: 'bg-blue-900/30 text-blue-400 border-blue-700/40',
+    api_key: 'bg-ae-primary/10 text-ae-accent border-ae-accent/40',
     token: 'bg-purple-900/30 text-purple-400 border-purple-700/40',
     secret: 'bg-yellow-900/30 text-yellow-400 border-yellow-700/40',
     credential: 'bg-orange-900/30 text-orange-400 border-orange-700/40',
@@ -395,7 +395,7 @@ function VaultTab() {
 
   const actionColors: Record<string, string> = {
     created: 'text-green-400',
-    accessed: 'text-blue-400',
+    accessed: 'text-ae-accent',
     updated: 'text-yellow-400',
     deleted: 'text-red-400',
     auto_captured: 'text-purple-400',

--- a/packages/web/app/routes/usage.tsx
+++ b/packages/web/app/routes/usage.tsx
@@ -34,7 +34,7 @@ function UsagePage() {
   const costByProvider: Record<string, number> = {};
   records.forEach((r) => { costByProvider[r.provider] = (costByProvider[r.provider] || 0) + r.cost; });
   const maxProviderCost = Math.max(...Object.values(costByProvider), 1);
-  const providerColors: Record<string, string> = { openai: "bg-green-500", anthropic: "bg-orange-500", openrouter: "bg-blue-500", google: "bg-yellow-500", xai: "bg-purple-500" };
+  const providerColors: Record<string, string> = { openai: "bg-green-500", anthropic: "bg-orange-500", openrouter: "bg-ae-accent", google: "bg-yellow-500", xai: "bg-purple-500" };
 
   // Top agents by usage
   const agentUsage: Record<string, { tokens: number; cost: number }> = {};
@@ -80,7 +80,7 @@ function UsagePage() {
         {/* Summary Cards */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {[
-            { label: "Total Tokens", value: formatTokens(totalTokens), icon: Zap, color: "text-blue-400", sub: `${records.length} requests` },
+            { label: "Total Tokens", value: formatTokens(totalTokens), icon: Zap, color: "text-ae-accent", sub: `${records.length} requests` },
             { label: "Total Cost", value: `$${totalCost.toFixed(2)}`, icon: DollarSign, color: "text-green-400", sub: `Avg $${(totalCost / Math.max(records.length, 1)).toFixed(3)}/req` },
             { label: "Active Agents", value: uniqueAgents.toString(), icon: Bot, color: "text-purple-400", sub: "Using LLM providers" },
             { label: "Total Requests", value: totalSessions.toString(), icon: Activity, color: "text-orange-400", sub: "In selected period" },

--- a/packages/web/app/styles/globals.css
+++ b/packages/web/app/styles/globals.css
@@ -2,57 +2,93 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+  Agentic Engineering Brand Palette
+  ─────────────────────────────────
+  Primary Blue  #1F337A  →  hsl(227 59% 30%)  — trust, logos, headings
+  Accent Blue   #6A81C7  →  hsl(225 45% 60%)  — interactive, highlights
+  Bone          #F5F5F5  →  hsl(0 0% 96%)     — backgrounds, white space
+  Charcoal      #1A1A1A  →  hsl(0 0% 10%)     — body text, grounding
+*/
+
 @layer base {
-  /* Default to dark theme (OpenClaw-style) */
+  /* ─── Dark Theme (default) ─────────────────────────────────────────── */
   :root {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 5.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 5.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 72.2% 50.6%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 0 72.2% 50.6%;
-    --radius: 0.5rem;
-    --sidebar: 240 10% 4.5%;
-    --sidebar-foreground: 240 5% 64.9%;
-    --sidebar-active: 0 72.2% 50.6%;
+    /* Deep navy background — primary blue family, very dark */
+    --background:          225 54%  9%;
+    --foreground:          0   0%  96%;   /* Bone */
+
+    --card:                225 47% 12%;
+    --card-foreground:     0   0%  96%;
+
+    --popover:             225 47% 12%;
+    --popover-foreground:  0   0%  96%;
+
+    /* Primary = Accent Blue (legible on dark backgrounds) */
+    --primary:             225 45% 60%;   /* #6A81C7 */
+    --primary-foreground:  0   0%  96%;   /* Bone */
+
+    --secondary:           225 40% 17%;
+    --secondary-foreground:0   0%  96%;
+
+    --muted:               225 38% 17%;
+    --muted-foreground:    225 20% 55%;
+
+    /* Accent = slightly brighter blue highlight */
+    --accent:              225 40% 20%;
+    --accent-foreground:   0   0%  96%;
+
+    --destructive:         0   62%  31%;
+    --destructive-foreground: 0 0% 96%;
+
+    --border:              225 35% 20%;
+    --input:               225 35% 20%;
+    --ring:                225 45% 60%;   /* Accent Blue */
+
+    --radius:              0.5rem;
+
+    /* Sidebar */
+    --sidebar:             225 56%  7%;
+    --sidebar-foreground:  225 20% 55%;
+    --sidebar-active:      225 45% 60%;   /* Accent Blue */
   }
 
+  /* ─── Light Theme ──────────────────────────────────────────────────── */
   .light {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 0 72.2% 50.6%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
+    --background:          0   0%  96%;   /* Bone #F5F5F5 */
+    --foreground:          0   0%  10%;   /* Charcoal #1A1A1A */
+
+    --card:                0   0% 100%;
+    --card-foreground:     0   0%  10%;
+
+    --popover:             0   0% 100%;
+    --popover-foreground:  0   0%  10%;
+
+    /* Primary = Primary Blue */
+    --primary:             227 59% 30%;   /* #1F337A */
+    --primary-foreground:  0   0%  96%;   /* Bone */
+
+    --secondary:           225 50% 93%;
+    --secondary-foreground:227 59% 30%;   /* Primary Blue */
+
+    --muted:               225 30% 93%;
+    --muted-foreground:    225 20% 45%;
+
+    /* Accent = light tint of Accent Blue */
+    --accent:              225 45% 90%;
+    --accent-foreground:   227 59% 30%;   /* Primary Blue */
+
+    --destructive:         0   84%  60%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 0 72.2% 50.6%;
-    --sidebar: 0 0% 98%;
-    --sidebar-foreground: 240 3.8% 46.1%;
-    --sidebar-active: 0 72.2% 50.6%;
+
+    --border:              225 30% 87%;
+    --input:               225 30% 87%;
+    --ring:                225 45% 60%;   /* Accent Blue */
+
+    /* Sidebar */
+    --sidebar:             0   0% 100%;
+    --sidebar-foreground:  225 15% 40%;
+    --sidebar-active:      227 59% 30%;   /* Primary Blue */
   }
 }
 
@@ -81,7 +117,7 @@
     border-radius: 3px;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--muted-foreground));
+    background: hsl(var(--primary) / 0.6);
   }
 }
 

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -38,6 +38,14 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        // ─── Agentic Engineering Brand Tokens ───────────────────────────
+        // Use these for direct Tailwind classes: bg-ae-primary, text-ae-accent, etc.
+        ae: {
+          primary:  "#1F337A",   // Primary Blue — trust, logos, headings
+          accent:   "#6A81C7",   // Accent Blue — interactive, highlights
+          bone:     "#F5F5F5",   // Bone — backgrounds, white space
+          charcoal: "#1A1A1A",   // Charcoal — body text
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
Applies the full AE color identity to the AgentForge dashboard.

## Palette
| Token | Hex | HSL | Usage |
|-------|-----|-----|-------|
| Primary Blue | `#1F337A` | 227 59% 30% | Logos, headings, light-mode primary |
| Accent Blue | `#6A81C7` | 225 45% 60% | Interactive elements, dark-mode primary |
| Bone | `#F5F5F5` | 0 0% 96% | Light-mode background, dark-mode foreground |
| Charcoal | `#1A1A1A` | 0 0% 10% | Body text |

## Changes
- **`globals.css`**: Dark theme = deep navy bg + accent blue primary. Light theme = bone bg + charcoal text + primary blue.
- **`tailwind.config.js`**: Added `ae.*` brand tokens — `bg-ae-primary`, `text-ae-accent`, `bg-ae-bone`, `text-ae-charcoal`
- **6 route files**: Replaced hardcoded `text-blue-400` / `bg-blue-500` with `text-ae-accent` / `bg-ae-accent`

All 710 tests pass. Build ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new brand color palette with customizable accent, primary, and neutral tones.
  * Added light theme support alongside the existing dark theme for improved visibility options.

* **Style**
  * Updated UI color scheme across chat, files, analytics, and settings pages to use the new accent colors for consistent branding.
  * Refined visual styling for improved theme coherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->