### PR TITLE
fix: add "use node" directive and @mastra/core dep to Convex templates

### DIFF
--- a/packages/cli/dist/default/convex/chat.ts
+++ b/packages/cli/dist/default/convex/chat.ts
@@ -1,3 +1,5 @@
+"use node";
+
 /**
  * Chat Actions for AgentForge
  *

--- a/packages/cli/dist/default/convex/mastraIntegration.ts
+++ b/packages/cli/dist/default/convex/mastraIntegration.ts
@@ -1,3 +1,5 @@
+"use node";
+
 /**
  * Mastra Integration Actions for Convex
  *

--- a/packages/cli/dist/default/package.json
+++ b/packages/cli/dist/default/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@agentforge-ai/core": "^0.4.0",
+    "@mastra/core": "^1.7.0",
     "convex": "^1.17.0",
     "zod": "^3.23.0"
   },

--- a/packages/cli/templates/default/convex/chat.ts
+++ b/packages/cli/templates/default/convex/chat.ts
@@ -1,3 +1,5 @@
+"use node";
+
 /**
  * Chat Actions for AgentForge
  *

--- a/packages/cli/templates/default/convex/mastraIntegration.ts
+++ b/packages/cli/templates/default/convex/mastraIntegration.ts
@@ -1,3 +1,5 @@
+"use node";
+
 /**
  * Mastra Integration Actions for Convex
  *

--- a/packages/cli/templates/default/package.json
+++ b/packages/cli/templates/default/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@agentforge-ai/core": "^0.4.0",
+    "@mastra/core": "^1.7.0",
     "convex": "^1.17.0",
     "zod": "^3.23.0"
   },


### PR DESCRIPTION
## Problem

When running `agentforge create`, the generated project fails to deploy to Convex with:

```
✘ [ERROR] Could not resolve "@mastra/core/agent"
  convex/mastraIntegration.ts:15:22
  convex/chat.ts:16:22
```

## Root Cause

Two issues in the default project template:

1. **Missing `"use node";` directive** — Convex has two runtimes: edge and Node.js. Without this directive, Convex bundles for the edge runtime which cannot resolve Node.js packages like `@mastra/core`.

2. **`@mastra/core` missing from `package.json`** — The template only had `@agentforge-ai/core`, `convex`, and `zod`. Since `@mastra/core` is imported directly in the generated Convex action files, it must be an explicit dep.

## Fix

- Add `"use node";` as the first line of `convex/mastraIntegration.ts` and `convex/chat.ts`
- Add `@mastra/core@^1.7.0` to `package.json` dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Node.js runtime configuration to template files.
  * Updated core framework dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->