### PR TITLE
feat(sprint30): AGE-137 API key bridge + AGE-138 model lists (7 providers)

### DIFF
--- a/packages/cli/dist/default/convex/apiKeys.ts
+++ b/packages/cli/dist/default/convex/apiKeys.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { mutation, query, internalQuery } from "./_generated/server";
 
 // Query: List API keys
 export const list = query({
@@ -129,5 +129,20 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     await ctx.db.delete(args.id);
     return { success: true };
+  },
+});
+
+// Internal Query: Get decrypted (raw) API key for a provider
+// This is used by mastraIntegration to pass the key to LLM providers
+export const getDecryptedForProvider = internalQuery({
+  args: { provider: v.string() },
+  handler: async (ctx, args) => {
+    const keys = await ctx.db
+      .query("apiKeys")
+      .withIndex("byProvider", (q) => q.eq("provider", args.provider))
+      .collect();
+    const active = keys.find((k) => k.isActive);
+    // Note: encryptedKey stores the raw key (not actually encrypted in current implementation)
+    return active?.encryptedKey ?? null;
   },
 });

--- a/packages/cli/dist/default/convex/chat.ts
+++ b/packages/cli/dist/default/convex/chat.ts
@@ -206,6 +206,7 @@ export const sendMessage = action({
       const modelId = agent.model || "openai/gpt-4o-mini";
 
       const result = await ctx.runAction(api.mastraIntegration.generateResponse, {
+        provider, // AGE-137: Pass provider for BYOK
         modelKey: `${provider}/${modelId}`,
         instructions: agent.instructions || "You are a helpful AI assistant built with AgentForge.",
         messages: conversationMessages,

--- a/packages/cli/dist/default/convex/mastraIntegration.ts
+++ b/packages/cli/dist/default/convex/mastraIntegration.ts
@@ -4,17 +4,62 @@
  * Mastra Integration Actions for Convex
  *
  * These actions run in the Convex Node.js runtime and execute LLM calls
- * using Mastra-native model routing with OpenRouter as the default provider.
+ * using Mastra with BYOK (Bring Your Own Key) from the Convex database.
  *
  * Architecture:
  * - For chat: use `chat.sendMessage` (preferred entry point)
  * - For programmatic agent execution: use `mastraIntegration.executeAgent`
- * - Model resolution: uses Mastra Agent with "provider/model-name" format
+ * - Model resolution: fetches API keys from database, creates AI SDK model instances
+ *
+ * AGE-137: API keys are stored in Convex 'apiKeys' table and fetched at inference time
+ * instead of relying on process.env which doesn't exist in Convex Node.js runtime.
  */
-import { action } from "./_generated/server";
+import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
+
+// AI SDK factory functions for BYOK (Bring Your Own Key)
+// These allow us to pass API keys directly instead of relying on process.env
+import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createXai } from "@ai-sdk/xai";
+
+/**
+ * Create an AI SDK model instance with the provided API key (BYOK).
+ *
+ * This function maps provider names to their AI SDK factory functions,
+ * allowing us to pass API keys directly instead of relying on process.env.
+ *
+ * @param provider - The LLM provider (e.g., 'openai', 'anthropic', 'google')
+ * @param apiKey - The API key fetched from the database
+ * @param modelId - The model identifier (e.g., 'gpt-4o-mini', 'claude-opus-4-6')
+ * @returns An AI SDK LanguageModel instance
+ */
+function createModelWithApiKey(provider: string, apiKey: string, modelId: string) {
+  // Strip provider prefix if present (e.g., "openai/gpt-4o" -> "gpt-4o")
+  const baseModelId = modelId.includes("/") ? modelId.split("/").slice(1).join("/") : modelId;
+
+  switch (provider) {
+    case "openai":
+      return createOpenAI({ apiKey })(baseModelId);
+    case "anthropic":
+      return createAnthropic({ apiKey })(baseModelId);
+    case "google":
+      return createGoogleGenerativeAI({ apiKey })(baseModelId);
+    case "xai":
+      return createXai({ apiKey })(baseModelId);
+    case "mistral":
+      return createOpenAI({ apiKey, baseURL: "https://api.mistral.ai/v1" })(baseModelId);
+    case "deepseek":
+      return createOpenAI({ apiKey, baseURL: "https://api.deepseek.com" })(baseModelId);
+    case "openrouter":
+      return createOpenAI({ apiKey, baseURL: "https://openrouter.ai/api/v1" })(baseModelId);
+    default:
+      throw new Error(`Unsupported provider: ${provider}`);
+  }
+}
 
 // Return type for executeAgent
 type ExecuteAgentResult = {
@@ -83,6 +128,15 @@ export const executeAgent = action({
       const modelId = agent.model || "openai/gpt-4o-mini";
       const modelKey = `${provider}/${modelId}`;
 
+      // AGE-137: Fetch API key from database for BYOK
+      const apiKey = await ctx.runQuery(internal.apiKeys.getDecryptedForProvider, { provider });
+      if (!apiKey) {
+        throw new Error(`No active API key found for provider: ${provider}. Please add an API key in Settings.`);
+      }
+
+      // Create AI SDK model instance with fetched API key
+      const resolvedModel = createModelWithApiKey(provider, apiKey, modelId);
+
       // Get conversation history for context
       const messages = await ctx.runQuery(api.messages.list, { threadId });
       const conversationMessages = (messages as Array<{ role: string; content: string }>)
@@ -92,12 +146,12 @@ export const executeAgent = action({
           content: m.content,
         }));
 
-      // Execute via Mastra Agent
+      // Execute via Mastra Agent with resolved model
       const mastraAgent = new Agent({
         id: "agentforge-executor",
         name: "agentforge-executor",
         instructions: agent.instructions || "You are a helpful AI assistant.",
-        model: modelKey,
+        model: resolvedModel,
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -234,7 +288,10 @@ export const executeWorkflow = action({
 /**
  * Thin LLM wrapper used by chat.sendMessage.
  *
- * Accepts a resolved modelKey, system instructions, and conversation messages.
+ * AGE-137: Now accepts provider argument for BYOK (Bring Your Own Key).
+ * Fetches the API key from the database and creates a model instance with it.
+ *
+ * Accepts a provider, modelKey, system instructions, and conversation messages.
  * Returns the generated text and token usage. No message storage — callers
  * handle persistence themselves.
  *
@@ -243,6 +300,7 @@ export const executeWorkflow = action({
  */
 export const generateResponse = action({
   args: {
+    provider: v.string(), // AGE-137: Added provider argument
     modelKey: v.string(),
     instructions: v.string(),
     messages: v.array(
@@ -250,7 +308,7 @@ export const generateResponse = action({
     ),
   },
   handler: async (
-    _ctx,
+    ctx,
     args
   ): Promise<{
     text: string;
@@ -260,11 +318,20 @@ export const generateResponse = action({
       totalTokens: number;
     } | null;
   }> => {
+    // AGE-137: Fetch API key from database for BYOK
+    const apiKey = await ctx.runQuery(internal.apiKeys.getDecryptedForProvider, { provider: args.provider });
+    if (!apiKey) {
+      throw new Error(`No active API key found for provider: ${args.provider}. Please add an API key in Settings.`);
+    }
+
+    // Create AI SDK model instance with fetched API key
+    const resolvedModel = createModelWithApiKey(args.provider, apiKey, args.modelKey);
+
     const mastraAgent = new Agent({
       id: "agentforge-executor",
       name: "agentforge-executor",
       instructions: args.instructions,
-      model: args.modelKey,
+      model: resolvedModel,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/cli/dist/default/dashboard/app/routes/agents.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/agents.tsx
@@ -7,13 +7,15 @@ import { Bot, Plus, Edit, Trash2, Search, X, Star } from 'lucide-react';
 
 export const Route = createFileRoute('/agents')({ component: AgentsPage });
 
-const providers = ['openai', 'anthropic', 'openrouter', 'google', 'xai'];
+const providers = ['openai', 'anthropic', 'google', 'xai', 'mistral', 'deepseek', 'openrouter'];
 const modelsByProvider: Record<string, string[]> = {
-  openai: ['gpt-4.1-mini', 'gpt-4o', 'gpt-4o-mini'],
-  google: ['gemini-2.5-flash', 'gemini-1.5-pro'],
-  anthropic: ['claude-3.5-sonnet', 'claude-3-haiku'],
-  openrouter: ['openrouter/auto'],
-  xai: ['grok-4', 'grok-3'],
+  openai: ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'o3', 'o4-mini'],
+  anthropic: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+  google: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.0-flash'],
+  xai: ['grok-3', 'grok-3-mini'],
+  mistral: ['mistral-large-latest', 'mistral-small-latest', 'codestral-latest'],
+  deepseek: ['deepseek-chat', 'deepseek-reasoner'],
+  openrouter: ['openrouter/auto', 'openai/gpt-4o', 'anthropic/claude-3.5-sonnet', 'google/gemini-2.0-flash'],
 };
 
 // Validation constraints

--- a/packages/cli/dist/default/package.json
+++ b/packages/cli/dist/default/package.json
@@ -14,6 +14,10 @@
     "dashboard:build": "cd dashboard && pnpm build"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.0.0",
+    "@ai-sdk/google": "^1.0.0",
+    "@ai-sdk/openai": "^1.0.0",
+    "@ai-sdk/xai": "^1.0.0",
     "@agentforge-ai/core": "^0.4.0",
     "@mastra/core": "^1.7.0",
     "convex": "^1.17.0",

--- a/packages/cli/templates/default/convex/apiKeys.ts
+++ b/packages/cli/templates/default/convex/apiKeys.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { mutation, query, internalQuery } from "./_generated/server";
 
 // Query: List API keys
 export const list = query({
@@ -129,5 +129,20 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     await ctx.db.delete(args.id);
     return { success: true };
+  },
+});
+
+// Internal Query: Get decrypted (raw) API key for a provider
+// This is used by mastraIntegration to pass the key to LLM providers
+export const getDecryptedForProvider = internalQuery({
+  args: { provider: v.string() },
+  handler: async (ctx, args) => {
+    const keys = await ctx.db
+      .query("apiKeys")
+      .withIndex("byProvider", (q) => q.eq("provider", args.provider))
+      .collect();
+    const active = keys.find((k) => k.isActive);
+    // Note: encryptedKey stores the raw key (not actually encrypted in current implementation)
+    return active?.encryptedKey ?? null;
   },
 });

--- a/packages/cli/templates/default/convex/chat.ts
+++ b/packages/cli/templates/default/convex/chat.ts
@@ -206,6 +206,7 @@ export const sendMessage = action({
       const modelId = agent.model || "openai/gpt-4o-mini";
 
       const result = await ctx.runAction(api.mastraIntegration.generateResponse, {
+        provider, // AGE-137: Pass provider for BYOK
         modelKey: `${provider}/${modelId}`,
         instructions: agent.instructions || "You are a helpful AI assistant built with AgentForge.",
         messages: conversationMessages,

--- a/packages/cli/templates/default/convex/mastraIntegration.ts
+++ b/packages/cli/templates/default/convex/mastraIntegration.ts
@@ -4,17 +4,62 @@
  * Mastra Integration Actions for Convex
  *
  * These actions run in the Convex Node.js runtime and execute LLM calls
- * using Mastra-native model routing with OpenRouter as the default provider.
+ * using Mastra with BYOK (Bring Your Own Key) from the Convex database.
  *
  * Architecture:
  * - For chat: use `chat.sendMessage` (preferred entry point)
  * - For programmatic agent execution: use `mastraIntegration.executeAgent`
- * - Model resolution: uses Mastra Agent with "provider/model-name" format
+ * - Model resolution: fetches API keys from database, creates AI SDK model instances
+ *
+ * AGE-137: API keys are stored in Convex 'apiKeys' table and fetched at inference time
+ * instead of relying on process.env which doesn't exist in Convex Node.js runtime.
  */
-import { action } from "./_generated/server";
+import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
+
+// AI SDK factory functions for BYOK (Bring Your Own Key)
+// These allow us to pass API keys directly instead of relying on process.env
+import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createXai } from "@ai-sdk/xai";
+
+/**
+ * Create an AI SDK model instance with the provided API key (BYOK).
+ *
+ * This function maps provider names to their AI SDK factory functions,
+ * allowing us to pass API keys directly instead of relying on process.env.
+ *
+ * @param provider - The LLM provider (e.g., 'openai', 'anthropic', 'google')
+ * @param apiKey - The API key fetched from the database
+ * @param modelId - The model identifier (e.g., 'gpt-4o-mini', 'claude-opus-4-6')
+ * @returns An AI SDK LanguageModel instance
+ */
+function createModelWithApiKey(provider: string, apiKey: string, modelId: string) {
+  // Strip provider prefix if present (e.g., "openai/gpt-4o" -> "gpt-4o")
+  const baseModelId = modelId.includes("/") ? modelId.split("/").slice(1).join("/") : modelId;
+
+  switch (provider) {
+    case "openai":
+      return createOpenAI({ apiKey })(baseModelId);
+    case "anthropic":
+      return createAnthropic({ apiKey })(baseModelId);
+    case "google":
+      return createGoogleGenerativeAI({ apiKey })(baseModelId);
+    case "xai":
+      return createXai({ apiKey })(baseModelId);
+    case "mistral":
+      return createOpenAI({ apiKey, baseURL: "https://api.mistral.ai/v1" })(baseModelId);
+    case "deepseek":
+      return createOpenAI({ apiKey, baseURL: "https://api.deepseek.com" })(baseModelId);
+    case "openrouter":
+      return createOpenAI({ apiKey, baseURL: "https://openrouter.ai/api/v1" })(baseModelId);
+    default:
+      throw new Error(`Unsupported provider: ${provider}`);
+  }
+}
 
 // Return type for executeAgent
 type ExecuteAgentResult = {
@@ -83,6 +128,15 @@ export const executeAgent = action({
       const modelId = agent.model || "openai/gpt-4o-mini";
       const modelKey = `${provider}/${modelId}`;
 
+      // AGE-137: Fetch API key from database for BYOK
+      const apiKey = await ctx.runQuery(internal.apiKeys.getDecryptedForProvider, { provider });
+      if (!apiKey) {
+        throw new Error(`No active API key found for provider: ${provider}. Please add an API key in Settings.`);
+      }
+
+      // Create AI SDK model instance with fetched API key
+      const resolvedModel = createModelWithApiKey(provider, apiKey, modelId);
+
       // Get conversation history for context
       const messages = await ctx.runQuery(api.messages.list, { threadId });
       const conversationMessages = (messages as Array<{ role: string; content: string }>)
@@ -92,12 +146,12 @@ export const executeAgent = action({
           content: m.content,
         }));
 
-      // Execute via Mastra Agent
+      // Execute via Mastra Agent with resolved model
       const mastraAgent = new Agent({
         id: "agentforge-executor",
         name: "agentforge-executor",
         instructions: agent.instructions || "You are a helpful AI assistant.",
-        model: modelKey,
+        model: resolvedModel,
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -234,7 +288,10 @@ export const executeWorkflow = action({
 /**
  * Thin LLM wrapper used by chat.sendMessage.
  *
- * Accepts a resolved modelKey, system instructions, and conversation messages.
+ * AGE-137: Now accepts provider argument for BYOK (Bring Your Own Key).
+ * Fetches the API key from the database and creates a model instance with it.
+ *
+ * Accepts a provider, modelKey, system instructions, and conversation messages.
  * Returns the generated text and token usage. No message storage — callers
  * handle persistence themselves.
  *
@@ -243,6 +300,7 @@ export const executeWorkflow = action({
  */
 export const generateResponse = action({
   args: {
+    provider: v.string(), // AGE-137: Added provider argument
     modelKey: v.string(),
     instructions: v.string(),
     messages: v.array(
@@ -250,7 +308,7 @@ export const generateResponse = action({
     ),
   },
   handler: async (
-    _ctx,
+    ctx,
     args
   ): Promise<{
     text: string;
@@ -260,11 +318,20 @@ export const generateResponse = action({
       totalTokens: number;
     } | null;
   }> => {
+    // AGE-137: Fetch API key from database for BYOK
+    const apiKey = await ctx.runQuery(internal.apiKeys.getDecryptedForProvider, { provider: args.provider });
+    if (!apiKey) {
+      throw new Error(`No active API key found for provider: ${args.provider}. Please add an API key in Settings.`);
+    }
+
+    // Create AI SDK model instance with fetched API key
+    const resolvedModel = createModelWithApiKey(args.provider, apiKey, args.modelKey);
+
     const mastraAgent = new Agent({
       id: "agentforge-executor",
       name: "agentforge-executor",
       instructions: args.instructions,
-      model: args.modelKey,
+      model: resolvedModel,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/cli/templates/default/dashboard/app/routes/agents.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/agents.tsx
@@ -7,13 +7,15 @@ import { Bot, Plus, Edit, Trash2, Search, X, Star } from 'lucide-react';
 
 export const Route = createFileRoute('/agents')({ component: AgentsPage });
 
-const providers = ['openai', 'anthropic', 'openrouter', 'google', 'xai'];
+const providers = ['openai', 'anthropic', 'google', 'xai', 'mistral', 'deepseek', 'openrouter'];
 const modelsByProvider: Record<string, string[]> = {
-  openai: ['gpt-4.1-mini', 'gpt-4o', 'gpt-4o-mini'],
-  google: ['gemini-2.5-flash', 'gemini-1.5-pro'],
-  anthropic: ['claude-3.5-sonnet', 'claude-3-haiku'],
-  openrouter: ['openrouter/auto'],
-  xai: ['grok-4', 'grok-3'],
+  openai: ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'o3', 'o4-mini'],
+  anthropic: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+  google: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.0-flash'],
+  xai: ['grok-3', 'grok-3-mini'],
+  mistral: ['mistral-large-latest', 'mistral-small-latest', 'codestral-latest'],
+  deepseek: ['deepseek-chat', 'deepseek-reasoner'],
+  openrouter: ['openrouter/auto', 'openai/gpt-4o', 'anthropic/claude-3.5-sonnet', 'google/gemini-2.0-flash'],
 };
 
 // Validation constraints

--- a/packages/cli/templates/default/package.json
+++ b/packages/cli/templates/default/package.json
@@ -14,6 +14,10 @@
     "dashboard:build": "cd dashboard && pnpm build"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.0.0",
+    "@ai-sdk/google": "^1.0.0",
+    "@ai-sdk/openai": "^1.0.0",
+    "@ai-sdk/xai": "^1.0.0",
     "@agentforge-ai/core": "^0.4.0",
     "@mastra/core": "^1.7.0",
     "convex": "^1.17.0",

--- a/packages/cli/templates/default/specs/active/AGE-137.spec.md
+++ b/packages/cli/templates/default/specs/active/AGE-137.spec.md
@@ -1,0 +1,67 @@
+# AGE-137: Fix API Key Bridge for AgentForge
+
+## Problem Statement
+`mastraIntegration.generateResponse` creates a Mastra Agent with only a model string (e.g., `openai/gpt-4.1-mini`). Mastra's router then calls `process.env.OPENAI_API_KEY`, which doesn't exist in the Convex Node.js runtime. API keys are stored in the Convex `apiKeys` table (field: `encryptedKey` contains the raw key string) but are never read at inference time.
+
+## Solution
+Implement Bring Your Own Key (BYOK) support by:
+1. Reading the API key from the `apiKeys` table for each provider
+2. Passing the key explicitly to the AI SDK provider factories
+3. Supporting all major LLM providers (OpenAI, Anthropic, Google, xAI, Mistral, DeepSeek, OpenRouter)
+
+## Acceptance Criteria
+
+### Given a user adds an OpenAI API key in Settings
+- When they send a chat message
+- Then the LLM responds without a `process.env` error
+
+### Given provider='openai'
+- When `generateResponse` is called
+- Then it uses `createOpenAI({ apiKey })` not `process.env`
+
+### Given provider='anthropic'
+- When `generateResponse` is called
+- Then it uses `createAnthropic({ apiKey })`
+
+### Given provider='google'
+- When `generateResponse` is called
+- Then it uses `createGoogleGenerativeAI({ apiKey })`
+
+### Given provider='openrouter'
+- When `generateResponse` is called
+- Then it uses OpenAI-compatible with `baseURL=https://openrouter.ai/api/v1`
+
+### Given no active key for provider
+- When `generateResponse` is called
+- Then it throws a clear error `No active API key found for provider: X`
+
+### Given provider='mistral'
+- When `executeAgent` is called
+- Then it uses OpenAI-compatible with `baseURL=https://api.mistral.ai/v1`
+
+### Given provider='deepseek'
+- When `executeAgent` is called
+- Then it uses OpenAI-compatible with `baseURL=https://api.deepseek.com`
+
+### Given provider='xai'
+- When `executeAgent` is called
+- Then it uses `createXai({ apiKey })`
+
+## Implementation Plan
+
+1. Add `getDecryptedForProvider` internal query to `apiKeys.ts`
+2. Update `generateResponse` in `mastraIntegration.ts` with BYOK logic
+3. Update `executeAgent` in `mastraIntegration.ts` with BYOK logic
+4. Update `chat.ts sendMessage` to pass provider argument
+5. Add missing `@ai-sdk/*` packages to package.json
+
+## Files to Modify
+- `packages/cli/dist/default/convex/apiKeys.ts`
+- `packages/cli/dist/default/convex/mastraIntegration.ts`
+- `packages/cli/dist/default/convex/chat.ts`
+- `packages/cli/dist/default/package.json`
+
+## Notes
+- The `encryptedKey` field stores the raw API key (not actually encrypted in current implementation)
+- This is a temporary fix; proper encryption should be added in a future spec
+- Mastra v1.7.0 removed Vercel AI SDK dependencies, so we use AI SDK provider factories directly

--- a/packages/cli/templates/default/specs/active/AGE-138.spec.md
+++ b/packages/cli/templates/default/specs/active/AGE-138.spec.md
@@ -1,0 +1,65 @@
+# AGE-138: Update Model Lists for AgentForge Dashboard
+
+## Summary
+Update the model picker in the dashboard to support 7 LLM providers with the latest models as of February 2026.
+
+## Stage: SPEC
+
+## Assertions
+
+### UI Model Picker
+- Model picker shows 7 providers: openai, anthropic, google, xai, mistral, deepseek, openrouter
+
+### Provider: OpenAI
+- gpt-4.1
+- gpt-4.1-mini
+- gpt-4.1-nano
+- gpt-4o
+- o3
+- o4-mini
+
+### Provider: Anthropic
+- claude-opus-4-6 (first option, highlighted)
+- claude-sonnet-4-6
+- claude-haiku-4-5
+
+### Provider: Google
+- gemini-2.5-pro
+- gemini-2.5-flash
+- gemini-2.0-flash
+
+### Provider: xAI
+- grok-3
+- grok-3-mini
+
+### Provider: Mistral
+- mistral-large-latest
+- mistral-small-latest
+- codestral-latest
+
+### Provider: DeepSeek
+- deepseek-chat
+- deepseek-reasoner
+
+### Provider: OpenRouter
+- openrouter/auto
+- openai/gpt-4o
+- anthropic/claude-3.5-sonnet
+- google/gemini-2.0-flash
+
+### Default New Agent
+- Provider: openai
+- Model: gpt-4.1-mini
+- Temperature: 0.7
+- Max Tokens: 4096
+
+## Files to Modify
+1. `packages/cli/dist/default/dashboard/app/routes/agents.tsx`
+   - Update `providers` array
+   - Update `modelsByProvider` constant
+   - Verify default form values
+
+## Out of Scope
+- chat.ts (AGE-137)
+- apiKeys.ts (AGE-137)
+- mastraIntegration.ts core BYOK logic (AGE-137)


### PR DESCRIPTION
## AGE-137 — Fix API Key Bridge (CRITICAL)

**Root cause fixed:** `mastraIntegration.generateResponse` was passing only a model string to Mastra, which then looked for `process.env.OPENAI_API_KEY` — an env var that doesn't exist in Convex runtime.

**What changed:**
- `convex/apiKeys.ts`: New `getDecryptedForProvider` `internalQuery` — returns active stored key for a provider via `internal.*` routing
- `convex/mastraIntegration.ts`: Both `generateResponse` and `executeAgent` now accept `provider` arg, query the stored key via `internal.apiKeys.getDecryptedForProvider`, then use BYOK AI SDK factories (`createOpenAI`, `createAnthropic`, `createGoogleGenerativeAI`, `createXai`) instead of env vars
- `convex/chat.ts`: Passes `provider` when calling `generateResponse`
- `package.json`: Added `@ai-sdk/anthropic`, `@ai-sdk/google`, `@ai-sdk/xai` deps
- Throws clear error: `'No active API key found for provider: X'` when no key stored

## AGE-138 — Updated Model Lists (7 Providers)

Replaced outdated models with 2026-current options:
- **OpenAI**: gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-4o, o3, o4-mini
- **Anthropic**: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5
- **Google**: gemini-2.5-pro, gemini-2.5-flash, gemini-2.0-flash
- **xAI**: grok-3, grok-3-mini
- **Mistral**: mistral-large-latest, mistral-small-latest, codestral-latest _(new)_
- **DeepSeek**: deepseek-chat, deepseek-reasoner _(new)_
- **OpenRouter**: auto + passthrough options

## Q&S ✓
- Zero `window.confirm()` | Zero new `as any` | `internal.*` routing verified
- `pnpm build` ✓ | `pnpm test` 82/82 ✓ | `dist/` ↔ `templates/` in sync ✓
- SpecSafe specs: `specs/active/AGE-137.spec.md` + `specs/active/AGE-138.spec.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Bring Your Own Key (BYOK) support enabling use of API keys from 7 major LLM providers: OpenAI, Anthropic, Google, xAI, Mistral, DeepSeek, and OpenRouter.
  * Expanded dashboard model picker with additional models for each supported provider.
  * Chat system updated to maintain provider context for accurate API key routing.

* **Dependencies**
  * Added AI SDK provider packages for enhanced multi-provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->