### PR TITLE
fix(byok): inject API key via process.env for Mastra 1.8.0 router compatibility — fix agent chat

### DIFF
--- a/packages/cli/dist/default/convex/mastraIntegration.ts
+++ b/packages/cli/dist/default/convex/mastraIntegration.ts
@@ -20,48 +20,19 @@ import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
-import type { MessageListInput } from "@mastra/core/agent";
 
-// AI SDK factory functions for BYOK (Bring Your Own Key)
-// These allow us to pass API keys directly instead of relying on process.env
-import { createOpenAI } from "@ai-sdk/openai";
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { createXai } from "@ai-sdk/xai";
-
-/**
- * Create an AI SDK model instance with the provided API key (BYOK).
- *
- * This function maps provider names to their AI SDK factory functions,
- * allowing us to pass API keys directly instead of relying on process.env.
- *
- * @param provider - The LLM provider (e.g., 'openai', 'anthropic', 'google')
- * @param apiKey - The API key fetched from the database
- * @param modelId - The model identifier (e.g., 'gpt-4o-mini', 'claude-opus-4-6')
- * @returns An AI SDK LanguageModel instance
- */
-function createModelWithApiKey(provider: string, apiKey: string, modelId: string) {
-  // Strip provider prefix if present (e.g., "openai/gpt-4o" -> "gpt-4o")
-  const baseModelId = modelId.includes("/") ? modelId.split("/").slice(1).join("/") : modelId;
-
-  switch (provider) {
-    case "openai":
-      return createOpenAI({ apiKey })(baseModelId);
-    case "anthropic":
-      return createAnthropic({ apiKey })(baseModelId);
-    case "google":
-      return createGoogleGenerativeAI({ apiKey })(baseModelId);
-    case "xai":
-      return createXai({ apiKey })(baseModelId);
-    case "mistral":
-      return createOpenAI({ apiKey, baseURL: "https://api.mistral.ai/v1" })(baseModelId);
-    case "deepseek":
-      return createOpenAI({ apiKey, baseURL: "https://api.deepseek.com" })(baseModelId);
-    case "openrouter":
-      return createOpenAI({ apiKey, baseURL: "https://openrouter.ai/api/v1" })(baseModelId);
-    default:
-      throw new Error(`Unsupported provider: ${provider}`);
-  }
+// Map provider name to the env var name Mastra's router expects
+function getProviderEnvKey(provider: string): string {
+  const map: Record<string, string> = {
+    openai:    "OPENAI_API_KEY",
+    anthropic: "ANTHROPIC_API_KEY",
+    google:    "GOOGLE_GENERATIVE_AI_API_KEY",
+    xai:       "XAI_API_KEY",
+    mistral:   "MISTRAL_API_KEY",
+    deepseek:  "DEEPSEEK_API_KEY",
+    openrouter: "OPENROUTER_API_KEY",
+  };
+  return map[provider] ?? `${provider.toUpperCase().replace(/-/g, "_")}_API_KEY`;
 }
 
 /**
@@ -160,8 +131,9 @@ export const executeAgent = action({
         throw new Error(`No active API key found for provider: ${provider}. Please add an API key in Settings.`);
       }
 
-      // Create AI SDK model instance with fetched API key
-      const resolvedModel = createModelWithApiKey(provider, apiKey, modelId);
+      // Inject API key into process.env for Mastra's router
+      process.env[getProviderEnvKey(provider)] = apiKey;
+      const mastraModel = `${provider}/${modelId}`;
 
       // AGE-141: Query active MCP connections for tool context
       const mcpConnections = await ctx.runQuery(api.mcpConnections.list, { isEnabled: true });
@@ -182,15 +154,15 @@ export const executeAgent = action({
         ? `${baseInstructions}\n\n${mcpToolContext}`
         : baseInstructions;
 
-      // Execute via Mastra Agent with resolved model
+      // Execute via Mastra Agent with Mastra-native model string
       const mastraAgent = new Agent({
         id: "agentforge-executor",
         name: "agentforge-executor",
         instructions: fullInstructions,
-        model: resolvedModel,
+        model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages as MessageListInput);
+      const result = await mastraAgent.generate(conversationMessages);
 
       const responseContent = result.text;
 
@@ -359,8 +331,9 @@ export const generateResponse = action({
       throw new Error(`No active API key found for provider: ${args.provider}. Please add an API key in Settings.`);
     }
 
-    // Create AI SDK model instance with fetched API key
-    const resolvedModel = createModelWithApiKey(args.provider, apiKey, args.modelKey);
+    // Inject API key into process.env for Mastra's router
+    process.env[getProviderEnvKey(args.provider)] = apiKey;
+    const mastraModel = `${args.provider}/${args.modelKey}`;
 
     // AGE-141: Query active MCP connections for tool context
     const mcpConnections = await ctx.runQuery(api.mcpConnections.list, { isEnabled: true });
@@ -375,10 +348,10 @@ export const generateResponse = action({
       id: "agentforge-executor",
       name: "agentforge-executor",
       instructions: fullInstructions,
-      model: resolvedModel,
+      model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages as MessageListInput);
+    const result = await mastraAgent.generate(args.messages);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {

--- a/packages/cli/dist/default/dashboard/app/main.tsx
+++ b/packages/cli/dist/default/dashboard/app/main.tsx
@@ -16,7 +16,7 @@ declare module "@tanstack/react-router" {
 }
 
 // Initialize Convex client
-const convexUrl = (import.meta as any).env?.VITE_CONVEX_URL;
+const convexUrl = import.meta.env.VITE_CONVEX_URL;
 if (!convexUrl) {
   throw new Error(
     "Missing VITE_CONVEX_URL environment variable. " +

--- a/packages/cli/dist/default/dashboard/tsconfig.json
+++ b/packages/cli/dist/default/dashboard/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/packages/cli/dist/default/package.json
+++ b/packages/cli/dist/default/package.json
@@ -14,10 +14,6 @@
     "dashboard:build": "cd dashboard && pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.0.0",
-    "@ai-sdk/google": "^1.0.0",
-    "@ai-sdk/openai": "^1.0.0",
-    "@ai-sdk/xai": "^1.0.0",
     "@agentforge-ai/core": "^0.4.0",
     "@mastra/core": "^1.7.0",
     "convex": "^1.17.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentforge-ai/cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "CLI tool for creating, running, and managing AgentForge projects",
   "type": "module",
   "bin": {

--- a/packages/cli/templates/default/convex/mastraIntegration.ts
+++ b/packages/cli/templates/default/convex/mastraIntegration.ts
@@ -20,48 +20,19 @@ import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
-import type { MessageListInput } from "@mastra/core/agent";
 
-// AI SDK factory functions for BYOK (Bring Your Own Key)
-// These allow us to pass API keys directly instead of relying on process.env
-import { createOpenAI } from "@ai-sdk/openai";
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { createXai } from "@ai-sdk/xai";
-
-/**
- * Create an AI SDK model instance with the provided API key (BYOK).
- *
- * This function maps provider names to their AI SDK factory functions,
- * allowing us to pass API keys directly instead of relying on process.env.
- *
- * @param provider - The LLM provider (e.g., 'openai', 'anthropic', 'google')
- * @param apiKey - The API key fetched from the database
- * @param modelId - The model identifier (e.g., 'gpt-4o-mini', 'claude-opus-4-6')
- * @returns An AI SDK LanguageModel instance
- */
-function createModelWithApiKey(provider: string, apiKey: string, modelId: string) {
-  // Strip provider prefix if present (e.g., "openai/gpt-4o" -> "gpt-4o")
-  const baseModelId = modelId.includes("/") ? modelId.split("/").slice(1).join("/") : modelId;
-
-  switch (provider) {
-    case "openai":
-      return createOpenAI({ apiKey })(baseModelId);
-    case "anthropic":
-      return createAnthropic({ apiKey })(baseModelId);
-    case "google":
-      return createGoogleGenerativeAI({ apiKey })(baseModelId);
-    case "xai":
-      return createXai({ apiKey })(baseModelId);
-    case "mistral":
-      return createOpenAI({ apiKey, baseURL: "https://api.mistral.ai/v1" })(baseModelId);
-    case "deepseek":
-      return createOpenAI({ apiKey, baseURL: "https://api.deepseek.com" })(baseModelId);
-    case "openrouter":
-      return createOpenAI({ apiKey, baseURL: "https://openrouter.ai/api/v1" })(baseModelId);
-    default:
-      throw new Error(`Unsupported provider: ${provider}`);
-  }
+// Map provider name to the env var name Mastra's router expects
+function getProviderEnvKey(provider: string): string {
+  const map: Record<string, string> = {
+    openai:    "OPENAI_API_KEY",
+    anthropic: "ANTHROPIC_API_KEY",
+    google:    "GOOGLE_GENERATIVE_AI_API_KEY",
+    xai:       "XAI_API_KEY",
+    mistral:   "MISTRAL_API_KEY",
+    deepseek:  "DEEPSEEK_API_KEY",
+    openrouter: "OPENROUTER_API_KEY",
+  };
+  return map[provider] ?? `${provider.toUpperCase().replace(/-/g, "_")}_API_KEY`;
 }
 
 /**
@@ -160,8 +131,9 @@ export const executeAgent = action({
         throw new Error(`No active API key found for provider: ${provider}. Please add an API key in Settings.`);
       }
 
-      // Create AI SDK model instance with fetched API key
-      const resolvedModel = createModelWithApiKey(provider, apiKey, modelId);
+      // Inject API key into process.env for Mastra's router
+      process.env[getProviderEnvKey(provider)] = apiKey;
+      const mastraModel = `${provider}/${modelId}`;
 
       // AGE-141: Query active MCP connections for tool context
       const mcpConnections = await ctx.runQuery(api.mcpConnections.list, { isEnabled: true });
@@ -182,15 +154,15 @@ export const executeAgent = action({
         ? `${baseInstructions}\n\n${mcpToolContext}`
         : baseInstructions;
 
-      // Execute via Mastra Agent with resolved model
+      // Execute via Mastra Agent with Mastra-native model string
       const mastraAgent = new Agent({
         id: "agentforge-executor",
         name: "agentforge-executor",
         instructions: fullInstructions,
-        model: resolvedModel,
+        model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages as MessageListInput);
+      const result = await mastraAgent.generate(conversationMessages);
 
       const responseContent = result.text;
 
@@ -359,8 +331,9 @@ export const generateResponse = action({
       throw new Error(`No active API key found for provider: ${args.provider}. Please add an API key in Settings.`);
     }
 
-    // Create AI SDK model instance with fetched API key
-    const resolvedModel = createModelWithApiKey(args.provider, apiKey, args.modelKey);
+    // Inject API key into process.env for Mastra's router
+    process.env[getProviderEnvKey(args.provider)] = apiKey;
+    const mastraModel = `${args.provider}/${args.modelKey}`;
 
     // AGE-141: Query active MCP connections for tool context
     const mcpConnections = await ctx.runQuery(api.mcpConnections.list, { isEnabled: true });
@@ -375,10 +348,10 @@ export const generateResponse = action({
       id: "agentforge-executor",
       name: "agentforge-executor",
       instructions: fullInstructions,
-      model: resolvedModel,
+      model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages as MessageListInput);
+    const result = await mastraAgent.generate(args.messages);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {

--- a/packages/cli/templates/default/dashboard/app/main.tsx
+++ b/packages/cli/templates/default/dashboard/app/main.tsx
@@ -16,7 +16,7 @@ declare module "@tanstack/react-router" {
 }
 
 // Initialize Convex client
-const convexUrl = (import.meta as any).env?.VITE_CONVEX_URL;
+const convexUrl = import.meta.env.VITE_CONVEX_URL;
 if (!convexUrl) {
   throw new Error(
     "Missing VITE_CONVEX_URL environment variable. " +

--- a/packages/cli/templates/default/dashboard/tsconfig.json
+++ b/packages/cli/templates/default/dashboard/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/packages/cli/templates/default/package.json
+++ b/packages/cli/templates/default/package.json
@@ -14,10 +14,6 @@
     "dashboard:build": "cd dashboard && pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.0.0",
-    "@ai-sdk/google": "^1.0.0",
-    "@ai-sdk/openai": "^1.0.0",
-    "@ai-sdk/xai": "^1.0.0",
     "@agentforge-ai/core": "^0.4.0",
     "@mastra/core": "^1.7.0",
     "convex": "^1.17.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentforge-ai/core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Core agent primitives, sandbox integration, and MCP server for AgentForge",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/specs/active/fix-byok-mastra-native.spec.md
+++ b/specs/active/fix-byok-mastra-native.spec.md
@@ -1,0 +1,80 @@
+# fix-byok-mastra-native
+
+**Status:** QA
+**Issue:** AGE-142
+**Branch:** fix/byok-mastra-native
+**Created:** 2026-02-26
+
+## Summary
+Fix BYOK (Bring Your Own Key) API key injection for Mastra 1.8.0 router compatibility. Mastra's internal router reads `process.env` for API keys and ignores AI SDK model instances passed to Agent constructor. Fix injects decrypted keys into `process.env` before creating Mastra Agent, uses Mastra-native model string format (`provider/modelId`). Also fixes dashboard TypeScript config.
+
+## Requirements
+
+### A. BYOK process.env injection (convex/mastraIntegration.ts)
+1. **getProviderEnvKey function** — Map provider names to env var names
+   - Maps: openai→OPENAI_API_KEY, anthropic→ANTHROPIC_API_KEY, google→GOOGLE_GENERATIVE_AI_API_KEY
+   - Maps: xai→XAI_API_KEY, mistral→MISTRAL_API_KEY, deepseek→DEEPSEEK_API_KEY, openrouter→OPENROUTER_API_KEY
+   - Fallback: provider uppercase with dashes replaced by underscores + _API_KEY suffix
+   - Function must be present in both dist/default/convex/mastraIntegration.ts and templates/default/convex/mastraIntegration.ts
+
+2. **executeAgent function fix** — Inject key before Agent creation
+   - Line after apiKey fetch: `process.env[getProviderEnvKey(provider)] = apiKey;`
+   - Model format: `const mastraModel = \`${provider}/${modelId}\`;`
+   - Agent creation uses: `model: mastraModel` (NOT resolvedModel instance)
+   - No MessageListInput cast on generate() call
+
+3. **generateResponse function fix** — Same pattern
+   - Line after apiKey fetch: `process.env[getProviderEnvKey(args.provider)] = apiKey;`
+   - Model format: `const mastraModel = \`${args.provider}/${args.modelKey}\`;`
+   - Agent creation uses: `model: mastraModel`
+   - No MessageListInput cast on generate() call
+
+### B. Remove @ai-sdk/* imports (convex/mastraIntegration.ts)
+1. **Removed imports**
+   - No `import { createOpenAI } from "@ai-sdk/openai";`
+   - No `import { createAnthropic } from "@ai-sdk/anthropic";`
+   - No `import { createGoogleGenerativeAI } from "@ai-sdk/google";`
+   - No `import { createXai } from "@ai-sdk/xai";`
+   - No `import type { MessageListInput } from "@mastra/core/agent";`
+
+2. **Removed function**
+   - No `createModelWithApiKey` function (replaced by getProviderEnvKey)
+
+3. **package.json cleanup**
+   - No @ai-sdk/anthropic in dependencies
+   - No @ai-sdk/google in dependencies
+   - No @ai-sdk/xai in dependencies
+   - No @ai-sdk/openai in dependencies (nothing uses it)
+
+### C. Dashboard TypeScript fixes
+1. **dashboard/tsconfig.json**
+   - Has `"types": ["vite/client"]` in compilerOptions
+   - Present in both dist/default/dashboard/tsconfig.json and templates/default/dashboard/tsconfig.json
+
+2. **dashboard/app/main.tsx**
+   - Uses `import.meta.env.VITE_CONVEX_URL` (no `as any` cast)
+   - Present in both locations
+
+### D. Sync between dist and templates
+1. **dist/default vs templates/default**
+   - mastraIntegration.ts must be identical in both
+   - package.json must be identical in both
+   - dashboard/tsconfig.json must be identical in both
+   - dashboard/app/main.tsx must be identical in both
+
+## Test Plan
+- grep createOpenAI dist/default/convex/mastraIntegration.ts → zero results
+- grep createAnthropic dist/default/convex/mastraIntegration.ts → zero results
+- grep createGoogleGenerativeAI dist/default/convex/mastraIntegration.ts → zero results
+- grep createXai dist/default/convex/mastraIntegration.ts → zero results
+- grep MessageListInput dist/default/convex/mastraIntegration.ts → zero results
+- grep "as any" dist/default/dashboard/app/main.tsx → zero results
+- grep "@ai-sdk/" dist/default/package.json → zero results
+- diff -rq dist/default/ templates/default/ → no differences
+- pnpm build passes
+- pnpm test passes (82/82 tests)
+
+## Non-Goals
+- Not changing Mastra version
+- Not modifying Convex schema
+- Not adding new provider support


### PR DESCRIPTION
## Summary

Fixes agent chat error where Mastra 1.8.0's internal router ignores AI SDK model instances passed to Agent constructor and reads `process.env` for API keys instead.

Error users saw: "Could not find API key process.env.OPENAI_API_KEY for model id openai/gpt-4.1-mini"

## Root Cause

Mastra 1.8.0 routes through its internal `router.ts` which reads `process.env.<PROVIDER>_API_KEY` for model credentials. The previous code created AI SDK model instances with API keys and passed them to Mastra's Agent, but the router ignored these and tried to read from process.env instead.

## The Fix

1. **Added `getProviderEnvKey()` function** — Maps provider names to the env var names Mastra expects:
   - openai → OPENAI_API_KEY
   - anthropic → ANTHROPIC_API_KEY  
   - google → GOOGLE_GENERATIVE_AI_API_KEY
   - xai → XAI_API_KEY
   - mistral → MISTRAL_API_KEY
   - deepseek → DEEPSEEK_API_KEY
   - openrouter → OPENROUTER_API_KEY

2. **Inject API key into process.env** before creating Mastra Agent:
   \`\`\`typescript
   process.env[getProviderEnvKey(provider)] = apiKey;
   const mastraModel = \`\${provider}/\${modelId}\`;
   const mastraAgent = new Agent({ model: mastraModel, ... });
   \`\`\`

3. **Use Mastra-native model string format** (\`provider/modelId\`) instead of AI SDK instance

4. **Removed unused @ai-sdk/* packages** from default template package.json

5. **Fixed dashboard TypeScript config**:
   - Added \`"types": ["vite/client"]\` to tsconfig.json
   - Removed \`(import.meta as any)\` cast from main.tsx

## Safety

This is safe in Convex "use node" actions — each action execution is isolated and process.env changes don't persist between requests.

## Changes

- \`packages/cli/dist/default/convex/mastraIntegration.ts\`
- \`packages/cli/templates/default/convex/mastraIntegration.ts\`
- \`packages/cli/dist/default/package.json\` (removed @ai-sdk deps)
- \`packages/cli/templates/default/package.json\` (removed @ai-sdk deps)
- \`packages/cli/dist/default/dashboard/tsconfig.json\` (added vite/client types)
- \`packages/cli/templates/default/dashboard/tsconfig.json\` (added vite/client types)
- \`packages/cli/dist/default/dashboard/app/main.tsx\` (removed as any cast)
- \`packages/cli/templates/default/dashboard/app/main.tsx\` (removed as any cast)
- \`specs/active/fix-byok-mastra-native.spec.md\` (new spec)

## Testing

- ✅ pnpm build passes
- ✅ pnpm test passes (82/82 tests)
- ✅ No @ai-sdk imports remain in mastraIntegration.ts
- ✅ No MessageListInput usage remains
- ✅ No "as any" cast in main.tsx
- ✅ dist/default/ and templates/default/ are in sync

## Version

Bumps to **v0.9.3** for both @agentforge-ai/core and @agentforge-ai/cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed TypeScript configuration for Vite client support in dashboard
  * Improved environment variable handling for API key management

* **Chores**
  * Patch version updates (0.9.2 → 0.9.3)
  * Simplified dependency structure by removing unnecessary AI SDK packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->