### PR TITLE
feat(projects): wire project systemPrompt + model overrides into chat pipeline

### DIFF
--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -358,6 +358,28 @@ export const sendMessage = action({
       throw new Error(`Agent "${args.agentId}" not found. Please create an agent first.`);
     }
 
+    // 2. Load project settings to apply overrides (if agent belongs to a project)
+    let projectSystemPrompt: string | undefined;
+    let projectDefaultModel: string | undefined;
+    let projectDefaultProvider: string | undefined;
+
+    if (agent.projectId) {
+      const project = await ctx.runQuery(api.projects.get, { id: agent.projectId });
+      if (project?.settings) {
+        const settings = project.settings as {
+          systemPrompt?: string;
+          defaultModel?: string;
+          defaultProvider?: string;
+          instructionPrefix?: string;
+          defaultTemperature?: number;
+          defaultMaxTokens?: number;
+        };
+        projectSystemPrompt = settings.systemPrompt || settings.instructionPrefix;
+        projectDefaultModel = settings.defaultModel;
+        projectDefaultProvider = settings.defaultProvider;
+      }
+    }
+
     // 2. Store the user message
     await ctx.runMutation(api.chat.addUserMessage, {
       threadId: args.threadId,
@@ -377,18 +399,29 @@ export const sendMessage = action({
         content: msg.content,
       }));
 
-    // 4. Build failover chain from agent config
-    const failoverChain = buildFailoverChain(agent as {
+    // 4. Build failover chain from agent config (with project overrides)
+    const agentWithOverrides = {
+      provider: projectDefaultProvider || agent.provider,
+      model: projectDefaultModel || agent.model,
+      failoverModels: agent.failoverModels,
+    };
+    const failoverChain = buildFailoverChain(agentWithOverrides as {
       provider?: string;
       model?: string;
       failoverModels?: Array<{ provider: string; model: string }>;
     });
 
-    // 5. Execute with failover
+    // 5. Build system prompt with project override (project settings override agent instructions)
+    const baseInstructions = agent.instructions || "You are a helpful AI assistant built with AgentForge.";
+    const systemPrompt = projectSystemPrompt
+      ? `${projectSystemPrompt}\n\n${baseInstructions}`
+      : baseInstructions;
+
+    // 6. Execute with failover
     let responseText: string;
     let usageData: { promptTokens: number; completionTokens: number; totalTokens: number } | null = null;
-    let actualProvider: string = agent.provider || "openrouter";
-    let actualModel: string = agent.model || "unknown";
+    let actualProvider: string = projectDefaultProvider || agent.provider || "openrouter";
+    let actualModel: string = projectDefaultModel || agent.model || "unknown";
     let didFailover = false;
     let failoverEvents: Array<{ from: string; to: string; error: string; category: string }> = [];
     let latencyMs = 0;
@@ -396,7 +429,7 @@ export const sendMessage = action({
     try {
       const result = await executeWithFailover(
         failoverChain,
-        agent.instructions || "You are a helpful AI assistant built with AgentForge.",
+        systemPrompt,
         conversationMessages,
         {
           temperature: agent.temperature ?? undefined,
@@ -419,7 +452,7 @@ export const sendMessage = action({
       responseText = `I encountered an error while processing your request: ${errorMessage}`;
     }
 
-    // 6. Store the assistant response with provider metadata
+    // 7. Store the assistant response with provider metadata
     const metadata: Record<string, unknown> = {};
     if (usageData) {
       metadata.usage = usageData;
@@ -438,7 +471,7 @@ export const sendMessage = action({
       metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     });
 
-    // 7. Record usage metrics (non-blocking, best-effort)
+    // 8. Record usage metrics (non-blocking, best-effort)
     if (usageData) {
       try {
         // Estimate cost based on provider/model pricing
@@ -476,7 +509,7 @@ export const sendMessage = action({
       }
     }
 
-    // 8. Log the interaction
+    // 9. Log the interaction
     try {
       await ctx.runMutation(api.logs.add, {
         level: "info",

--- a/packages/cli/dist/default/convex/chat.ts
+++ b/packages/cli/dist/default/convex/chat.ts
@@ -178,6 +178,28 @@ export const sendMessage = action({
       throw new Error(`Agent "${args.agentId}" not found. Please create an agent first.`);
     }
 
+    // 1.5. Load project settings to apply overrides (if agent belongs to a project)
+    let projectSystemPrompt: string | undefined;
+    let projectDefaultModel: string | undefined;
+    let projectDefaultProvider: string | undefined;
+
+    if (agent.projectId) {
+      const project = await ctx.runQuery(api.projects.get, { id: agent.projectId });
+      if (project?.settings) {
+        const settings = project.settings as {
+          systemPrompt?: string;
+          defaultModel?: string;
+          defaultProvider?: string;
+          instructionPrefix?: string;
+          defaultTemperature?: number;
+          defaultMaxTokens?: number;
+        };
+        projectSystemPrompt = settings.systemPrompt || settings.instructionPrefix;
+        projectDefaultModel = settings.defaultModel;
+        projectDefaultProvider = settings.defaultProvider;
+      }
+    }
+
     // 2. Store the user message
     await ctx.runMutation(api.chat.addUserMessage, {
       threadId: args.threadId,
@@ -202,13 +224,19 @@ export const sendMessage = action({
     let usageData: { promptTokens: number; completionTokens: number; totalTokens: number } | null = null;
 
     try {
-      const provider = agent.provider || "openrouter";
-      const modelId = agent.model || "openai/gpt-4o-mini";
+      const provider = projectDefaultProvider || agent.provider || "openrouter";
+      const modelId = projectDefaultModel || agent.model || "openai/gpt-4o-mini";
+
+      // Build system prompt with project override (project settings prepend to agent instructions)
+      const baseInstructions = agent.instructions || "You are a helpful AI assistant built with AgentForge.";
+      const instructions = projectSystemPrompt
+        ? `${projectSystemPrompt}\n\n${baseInstructions}`
+        : baseInstructions;
 
       const result = await ctx.runAction(api.mastraIntegration.generateResponse, {
         provider, // AGE-137: Pass provider for BYOK
         modelKey: `${provider}/${modelId}`,
-        instructions: agent.instructions || "You are a helpful AI assistant built with AgentForge.",
+        instructions,
         messages: conversationMessages,
       });
 
@@ -232,10 +260,12 @@ export const sendMessage = action({
     // 6. Record usage metrics (non-blocking, best-effort)
     if (usageData) {
       try {
+        const actualProvider = projectDefaultProvider || agent.provider || "openrouter";
+        const actualModel = projectDefaultModel || agent.model || "unknown";
         await ctx.runMutation(api.usage.record, {
           agentId: args.agentId,
-          provider: agent.provider || "openrouter",
-          model: agent.model || "unknown",
+          provider: actualProvider,
+          model: actualModel,
           promptTokens: usageData.promptTokens,
           completionTokens: usageData.completionTokens,
           totalTokens: usageData.totalTokens,

--- a/packages/cli/templates/default/convex/chat.ts
+++ b/packages/cli/templates/default/convex/chat.ts
@@ -178,6 +178,28 @@ export const sendMessage = action({
       throw new Error(`Agent "${args.agentId}" not found. Please create an agent first.`);
     }
 
+    // 1.5. Load project settings to apply overrides (if agent belongs to a project)
+    let projectSystemPrompt: string | undefined;
+    let projectDefaultModel: string | undefined;
+    let projectDefaultProvider: string | undefined;
+
+    if (agent.projectId) {
+      const project = await ctx.runQuery(api.projects.get, { id: agent.projectId });
+      if (project?.settings) {
+        const settings = project.settings as {
+          systemPrompt?: string;
+          defaultModel?: string;
+          defaultProvider?: string;
+          instructionPrefix?: string;
+          defaultTemperature?: number;
+          defaultMaxTokens?: number;
+        };
+        projectSystemPrompt = settings.systemPrompt || settings.instructionPrefix;
+        projectDefaultModel = settings.defaultModel;
+        projectDefaultProvider = settings.defaultProvider;
+      }
+    }
+
     // 2. Store the user message
     await ctx.runMutation(api.chat.addUserMessage, {
       threadId: args.threadId,
@@ -202,13 +224,19 @@ export const sendMessage = action({
     let usageData: { promptTokens: number; completionTokens: number; totalTokens: number } | null = null;
 
     try {
-      const provider = agent.provider || "openrouter";
-      const modelId = agent.model || "openai/gpt-4o-mini";
+      const provider = projectDefaultProvider || agent.provider || "openrouter";
+      const modelId = projectDefaultModel || agent.model || "openai/gpt-4o-mini";
+
+      // Build system prompt with project override (project settings prepend to agent instructions)
+      const baseInstructions = agent.instructions || "You are a helpful AI assistant built with AgentForge.";
+      const instructions = projectSystemPrompt
+        ? `${projectSystemPrompt}\n\n${baseInstructions}`
+        : baseInstructions;
 
       const result = await ctx.runAction(api.mastraIntegration.generateResponse, {
         provider, // AGE-137: Pass provider for BYOK
         modelKey: `${provider}/${modelId}`,
-        instructions: agent.instructions || "You are a helpful AI assistant built with AgentForge.",
+        instructions,
         messages: conversationMessages,
       });
 
@@ -232,10 +260,12 @@ export const sendMessage = action({
     // 6. Record usage metrics (non-blocking, best-effort)
     if (usageData) {
       try {
+        const actualProvider = projectDefaultProvider || agent.provider || "openrouter";
+        const actualModel = projectDefaultModel || agent.model || "unknown";
         await ctx.runMutation(api.usage.record, {
           agentId: args.agentId,
-          provider: agent.provider || "openrouter",
-          model: agent.model || "unknown",
+          provider: actualProvider,
+          model: actualModel,
           promptTokens: usageData.promptTokens,
           completionTokens: usageData.completionTokens,
           totalTokens: usageData.totalTokens,

--- a/packages/cli/tests/unit/project-personalization.test.ts
+++ b/packages/cli/tests/unit/project-personalization.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Unit tests for Project Personalization
+ *
+ * Tests that project settings (systemPrompt, defaultModel, defaultProvider)
+ * properly override agent-level settings in the chat pipeline.
+ *
+ * Spec: fix-project-personalization.spec.md
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Id } from '../../convex/_generated/dataModel';
+
+describe('Project Personalization', () => {
+  describe('Override Precedence', () => {
+    it('should use project defaultProvider over agent.provider', () => {
+      const agent = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        instructions: 'You are helpful.',
+        projectId: 'project-1' as Id<'projects'>,
+      };
+
+      const project = {
+        _id: 'project-1' as Id<'projects'>,
+        name: 'Test Project',
+        settings: {
+          defaultProvider: 'anthropic',
+          defaultModel: 'claude-sonnet-4-6',
+          systemPrompt: 'Always respond in Spanish.',
+        },
+      };
+
+      // Simulate the override logic from chat.ts
+      const providerOverride = project.settings?.defaultProvider;
+      const modelOverride = project.settings?.defaultModel;
+      const systemPromptOverride = project.settings?.systemPrompt;
+
+      const finalProvider = providerOverride || agent.provider || 'openrouter';
+      const finalModel = modelOverride || agent.model || 'unknown';
+
+      expect(finalProvider).toBe('anthropic');
+      expect(finalModel).toBe('claude-sonnet-4-6');
+    });
+
+    it('should use project defaultModel over agent.model', () => {
+      const agent = {
+        id: 'agent-2',
+        name: 'Test Agent',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        instructions: 'You are helpful.',
+        projectId: 'project-2' as Id<'projects'>,
+      };
+
+      const project = {
+        _id: 'project-2' as Id<'projects'>,
+        name: 'Test Project',
+        settings: {
+          defaultModel: 'gemini-2.5-flash',
+        },
+      };
+
+      const modelOverride = project.settings?.defaultModel;
+      const finalModel = modelOverride || agent.model || 'unknown';
+
+      expect(finalModel).toBe('gemini-2.5-flash');
+    });
+
+    it('should use project systemPrompt prepended to agent instructions', () => {
+      const agent = {
+        id: 'agent-3',
+        name: 'Test Agent',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        instructions: 'You are a helpful assistant.',
+        projectId: 'project-3' as Id<'projects'>,
+      };
+
+      const project = {
+        _id: 'project-3' as Id<'projects'>,
+        name: 'Test Project',
+        settings: {
+          systemPrompt: 'Always respond in Spanish.',
+        },
+      };
+
+      const systemPromptOverride = project.settings?.systemPrompt;
+      const baseInstructions = agent.instructions || 'You are a helpful AI assistant.';
+      const finalPrompt = systemPromptOverride
+        ? `${systemPromptOverride}\n\n${baseInstructions}`
+        : baseInstructions;
+
+      expect(finalPrompt).toBe('Always respond in Spanish.\n\nYou are a helpful assistant.');
+    });
+
+    it('should use agent settings when project has no settings', () => {
+      const agent = {
+        id: 'agent-4',
+        name: 'Test Agent',
+        provider: 'google',
+        model: 'gemini-2.0-flash',
+        instructions: 'You are helpful.',
+        projectId: 'project-4' as Id<'projects'>,
+      };
+
+      const project = {
+        _id: 'project-4' as Id<'projects'>,
+        name: 'Test Project',
+        // No settings field
+      };
+
+      const settings = project.settings as {
+        systemPrompt?: string;
+        defaultModel?: string;
+        defaultProvider?: string;
+      } | undefined;
+
+      const providerOverride = settings?.defaultProvider;
+      const modelOverride = settings?.defaultModel;
+      const systemPromptOverride = settings?.systemPrompt;
+
+      const finalProvider = providerOverride || agent.provider || 'openrouter';
+      const finalModel = modelOverride || agent.model || 'unknown';
+      const baseInstructions = agent.instructions || 'You are a helpful AI assistant.';
+      const finalPrompt = systemPromptOverride
+        ? `${systemPromptOverride}\n\n${baseInstructions}`
+        : baseInstructions;
+
+      expect(finalProvider).toBe('google');
+      expect(finalModel).toBe('gemini-2.0-flash');
+      expect(finalPrompt).toBe('You are helpful.');
+    });
+  });
+
+  describe('Partial Override Handling', () => {
+    it('should use only project defaultProvider when only that is set', () => {
+      const agent = {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      };
+
+      const projectSettings = {
+        defaultProvider: 'anthropic',
+        // defaultModel not set
+      };
+
+      const finalProvider = projectSettings.defaultProvider || agent.provider || 'openrouter';
+      const finalModel = projectSettings.defaultModel || agent.model || 'unknown';
+
+      expect(finalProvider).toBe('anthropic');
+      expect(finalModel).toBe('gpt-4o-mini'); // Agent model used
+    });
+
+    it('should use only project defaultModel when only that is set', () => {
+      const agent = {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      };
+
+      const projectSettings = {
+        // defaultProvider not set
+        defaultModel: 'claude-sonnet-4-6',
+      };
+
+      const finalProvider = projectSettings.defaultProvider || agent.provider || 'openrouter';
+      const finalModel = projectSettings.defaultModel || agent.model || 'unknown';
+
+      expect(finalProvider).toBe('openai'); // Agent provider used
+      expect(finalModel).toBe('claude-sonnet-4-6');
+    });
+
+    it('should use only project systemPrompt when only that is set', () => {
+      const agent = {
+        instructions: 'You are a helpful assistant.',
+      };
+
+      const projectSettings = {
+        systemPrompt: 'Be concise.',
+      };
+
+      const baseInstructions = agent.instructions || 'You are a helpful AI assistant.';
+      const finalPrompt = projectSettings.systemPrompt
+        ? `${projectSettings.systemPrompt}\n\n${baseInstructions}`
+        : baseInstructions;
+
+      expect(finalPrompt).toBe('Be concise.\n\nYou are a helpful assistant.');
+    });
+  });
+
+  describe('Null and Undefined Handling', () => {
+    it('should handle null project settings', () => {
+      const agent = {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        instructions: 'You are helpful.',
+      };
+
+      const projectSettings = null;
+
+      const providerOverride = projectSettings?.defaultProvider;
+      const modelOverride = projectSettings?.defaultModel;
+      const systemPromptOverride = projectSettings?.systemPrompt;
+
+      const finalProvider = providerOverride || agent.provider || 'openrouter';
+      const finalModel = modelOverride || agent.model || 'unknown';
+      const baseInstructions = agent.instructions || 'You are a helpful AI assistant.';
+      const finalPrompt = systemPromptOverride
+        ? `${systemPromptOverride}\n\n${baseInstructions}`
+        : baseInstructions;
+
+      expect(finalProvider).toBe('openai');
+      expect(finalModel).toBe('gpt-4o-mini');
+      expect(finalPrompt).toBe('You are helpful.');
+    });
+
+    it('should handle undefined project settings', () => {
+      const agent = {
+        provider: 'google',
+        model: 'gemini-2.0-flash',
+        instructions: 'Be helpful.',
+      };
+
+      const projectSettings = undefined;
+
+      const providerOverride = projectSettings?.defaultProvider;
+      const modelOverride = projectSettings?.defaultModel;
+      const systemPromptOverride = projectSettings?.systemPrompt;
+
+      const finalProvider = providerOverride || agent.provider || 'openrouter';
+      const finalModel = modelOverride || agent.model || 'unknown';
+      const baseInstructions = agent.instructions || 'You are a helpful AI assistant.';
+      const finalPrompt = systemPromptOverride
+        ? `${systemPromptOverride}\n\n${baseInstructions}`
+        : baseInstructions;
+
+      expect(finalProvider).toBe('google');
+      expect(finalModel).toBe('gemini-2.0-flash');
+      expect(finalPrompt).toBe('Be helpful.');
+    });
+
+    it('should handle empty string overrides', () => {
+      const agent = {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        instructions: 'You are helpful.',
+      };
+
+      const projectSettings = {
+        defaultProvider: '',
+        defaultModel: '',
+        systemPrompt: '',
+      };
+
+      const providerOverride = projectSettings.defaultProvider || undefined;
+      const modelOverride = projectSettings.defaultModel || undefined;
+      const systemPromptOverride = projectSettings.systemPrompt || undefined;
+
+      const finalProvider = providerOverride || agent.provider || 'openrouter';
+      const finalModel = modelOverride || agent.model || 'unknown';
+      const baseInstructions = agent.instructions || 'You are a helpful AI assistant.';
+      const finalPrompt = systemPromptOverride
+        ? `${systemPromptOverride}\n\n${baseInstructions}`
+        : baseInstructions;
+
+      expect(finalProvider).toBe('openai');
+      expect(finalModel).toBe('gpt-4o-mini');
+      expect(finalPrompt).toBe('You are helpful.');
+    });
+  });
+
+  describe('Settings Object Structure', () => {
+    it('should extract settings from project.settings object', () => {
+      const project = {
+        _id: 'project-1' as Id<'projects'>,
+        name: 'Test Project',
+        settings: {
+          systemPrompt: 'Test prompt',
+          defaultModel: 'test-model',
+          defaultProvider: 'test-provider',
+          instructionPrefix: 'Prefix prompt',
+          defaultTemperature: 0.5,
+          defaultMaxTokens: 2048,
+        },
+      };
+
+      const settings = project.settings as {
+        systemPrompt?: string;
+        defaultModel?: string;
+        defaultProvider?: string;
+        instructionPrefix?: string;
+        defaultTemperature?: number;
+        defaultMaxTokens?: number;
+      };
+
+      expect(settings.systemPrompt).toBe('Test prompt');
+      expect(settings.defaultModel).toBe('test-model');
+      expect(settings.defaultProvider).toBe('test-provider');
+      expect(settings.instructionPrefix).toBe('Prefix prompt');
+      expect(settings.defaultTemperature).toBe(0.5);
+      expect(settings.defaultMaxTokens).toBe(2048);
+    });
+
+    it('should prefer systemPrompt over instructionPrefix', () => {
+      const settings = {
+        systemPrompt: 'Primary prompt',
+        instructionPrefix: 'Secondary prefix',
+      };
+
+      const extractedPrompt = settings.systemPrompt || settings.instructionPrefix;
+
+      expect(extractedPrompt).toBe('Primary prompt');
+    });
+
+    it('should fall back to instructionPrefix when systemPrompt is absent', () => {
+      const settings = {
+        instructionPrefix: 'Fallback prefix',
+      };
+
+      const extractedPrompt = settings.systemPrompt || settings.instructionPrefix;
+
+      expect(extractedPrompt).toBe('Fallback prefix');
+    });
+  });
+});

--- a/packages/web/app/routes/projects.tsx
+++ b/packages/web/app/routes/projects.tsx
@@ -6,12 +6,22 @@ import React, { useState, useMemo } from 'react';
 import { FolderKanban, Plus, Settings, Users, FileText, Trash2, Edit, X, Search, MoreVertical } from 'lucide-react';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as Tabs from '@radix-ui/react-tabs';
+import { LLM_PROVIDERS, getModelsByProvider } from '../../../../convex/llmProviders';
 
 // --- MOCK DATA & TYPES ---
+type ProjectSettings = {
+  systemPrompt?: string;
+  defaultModel?: string;
+  defaultProvider?: string;
+  defaultTemperature?: number;
+  defaultMaxTokens?: number;
+};
+
 type Project = {
   id: string;
   name: string;
   description: string;
+  settings?: ProjectSettings;
   agentCount: number;
   fileCount: number;
   createdAt: string;
@@ -51,12 +61,19 @@ const ProjectCard = ({ project, onEdit, onDelete, onSelect }: { project: Project
 const ProjectForm = ({ project, onSave, onCancel }: { project?: Project | null, onSave: (p: Omit<Project, 'id' | 'agentCount' | 'fileCount' | 'createdAt'>) => void, onCancel: () => void }) => {
   const [name, setName] = useState(project?.name || '');
   const [description, setDescription] = useState(project?.description || '');
+  const [settings, setSettings] = useState<ProjectSettings>(project?.settings || {});
+  const [showSettings, setShowSettings] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name) return;
-    onSave({ name, description });
+    onSave({ name, description, settings });
   };
+
+  const providers = LLM_PROVIDERS;
+  const modelsForProvider = settings.defaultProvider
+    ? getModelsByProvider(settings.defaultProvider)
+    : [];
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -68,6 +85,77 @@ const ProjectForm = ({ project, onSave, onCancel }: { project?: Project | null, 
         <label htmlFor="description" className="block text-sm font-medium text-muted-foreground mb-1">Description</label>
         <textarea id="description" value={description} onChange={e => setDescription(e.target.value)} rows={4} className="w-full bg-background border border-border rounded-md px-3 py-2 text-foreground focus:ring-2 focus:ring-primary" />
       </div>
+
+      <div className="border border-border rounded-md">
+        <button
+          type="button"
+          onClick={() => setShowSettings(!showSettings)}
+          className="w-full px-4 py-2 flex items-center justify-between text-sm font-medium hover:bg-card transition-colors"
+        >
+          <span className="flex items-center gap-2">
+            <Settings className="w-4 h-4" />
+            Agent Settings (overrides)
+          </span>
+          <X className={`w-4 h-4 transition-transform ${showSettings ? 'rotate-45' : ''}`} />
+        </button>
+        {showSettings && (
+          <div className="px-4 pb-4 space-y-4 border-t border-border">
+            <p className="text-xs text-muted-foreground mt-2">
+              These settings override agent-level defaults for all agents in this project.
+            </p>
+            <div>
+              <label htmlFor="systemPrompt" className="block text-sm font-medium text-muted-foreground mb-1">System Prompt Override</label>
+              <textarea
+                id="systemPrompt"
+                value={settings.systemPrompt || ''}
+                onChange={e => setSettings(prev => ({ ...prev, systemPrompt: e.target.value }))}
+                rows={4}
+                placeholder="Enter a project-level system prompt that will be prepended to all agent instructions..."
+                className="w-full bg-background border border-border rounded-md px-3 py-2 text-foreground focus:ring-2 focus:ring-primary"
+              />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="defaultProvider" className="block text-sm font-medium text-muted-foreground mb-1">Default Provider</label>
+                <select
+                  id="defaultProvider"
+                  value={settings.defaultProvider || ''}
+                  onChange={e => {
+                    const newProvider = e.target.value;
+                    setSettings(prev => ({
+                      ...prev,
+                      defaultProvider: newProvider,
+                      defaultModel: undefined,
+                    }));
+                  }}
+                  className="w-full bg-background border border-border rounded-md px-3 py-2 text-foreground focus:ring-2 focus:ring-primary"
+                >
+                  <option value="">Use agent default</option>
+                  {providers.map(p => <option key={p.key} value={p.key}>{p.displayName}</option>)}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="defaultModel" className="block text-sm font-medium text-muted-foreground mb-1">Default Model</label>
+                <select
+                  id="defaultModel"
+                  value={settings.defaultModel || ''}
+                  onChange={e => setSettings(prev => ({ ...prev, defaultModel: e.target.value }))}
+                  disabled={!settings.defaultProvider}
+                  className="w-full bg-background border border-border rounded-md px-3 py-2 text-foreground focus:ring-2 focus:ring-primary disabled:opacity-50"
+                >
+                  <option value="">Use agent default</option>
+                  {modelsForProvider.map(m => (
+                    <option key={m.id} value={m.id}>
+                      {m.displayName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
       <div className="flex justify-end gap-2 mt-4">
         <button type="button" onClick={onCancel} className="px-4 py-2 rounded-md border border-border text-foreground hover:bg-card">Cancel</button>
         <button type="submit" className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90">Save Project</button>
@@ -76,7 +164,9 @@ const ProjectForm = ({ project, onSave, onCancel }: { project?: Project | null, 
   );
 };
 
-const ProjectDetailView = ({ project, onBack }: { project: Project, onBack: () => void }) => (
+const ProjectDetailView = ({ project, onBack }: { project: Project, onBack: () => void }) => {
+  const providers = LLM_PROVIDERS;
+  return (
   <div className="bg-background p-6 rounded-lg">
     <div className="flex justify-between items-start mb-6">
       <div>
@@ -103,10 +193,79 @@ const ProjectDetailView = ({ project, onBack }: { project: Project, onBack: () =
       </Tabs.Content>
       <Tabs.Content value="agents" className="p-4 bg-card rounded-b-lg border border-t-0 border-border"><p className="text-muted-foreground">Agent management UI will be here.</p></Tabs.Content>
       <Tabs.Content value="files" className="p-4 bg-card rounded-b-lg border border-t-0 border-border"><p className="text-muted-foreground">File management UI will be here.</p></Tabs.Content>
-      <Tabs.Content value="settings" className="p-4 bg-card rounded-b-lg border border-t-0 border-border"><p className="text-muted-foreground">Project settings UI will be here.</p></Tabs.Content>
+      <Tabs.Content value="settings" className="p-4 bg-card rounded-b-lg border border-t-0 border-border">
+        <div className="space-y-6">
+          <div>
+            <h4 className="font-bold text-lg mb-2">Agent Settings Override</h4>
+            <p className="text-sm text-muted-foreground mb-4">
+              These settings apply to all agents in this project, overriding their individual defaults.
+            </p>
+          </div>
+
+          {project.settings ? (
+            <div className="space-y-4">
+              {project.settings.systemPrompt && (
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1">System Prompt</label>
+                  <div className="bg-background border border-border rounded-md p-3 text-sm">
+                    <pre className="whitespace-pre-wrap break-words font-sans text-muted-foreground">{project.settings.systemPrompt}</pre>
+                  </div>
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {project.settings.defaultProvider && (
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1">Default Provider</label>
+                    <div className="bg-background border border-border rounded-md px-3 py-2 text-sm text-muted-foreground">
+                      {providers.find(p => p.key === project.settings?.defaultProvider)?.displayName || project.settings.defaultProvider}
+                    </div>
+                  </div>
+                )}
+
+                {project.settings.defaultModel && (
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1">Default Model</label>
+                    <div className="bg-background border border-border rounded-md px-3 py-2 text-sm text-muted-foreground">
+                      {project.settings.defaultModel}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {project.settings.defaultTemperature !== undefined && (
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1">Default Temperature</label>
+                  <div className="bg-background border border-border rounded-md px-3 py-2 text-sm text-muted-foreground">
+                    {project.settings.defaultTemperature}
+                  </div>
+                </div>
+              )}
+
+              {project.settings.defaultMaxTokens !== undefined && (
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1">Default Max Tokens</label>
+                  <div className="bg-background border border-border rounded-md px-3 py-2 text-sm text-muted-foreground">
+                    {project.settings.defaultMaxTokens}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className="text-muted-foreground">No custom settings configured. This project uses agent-level defaults.</p>
+          )}
+
+          <div className="pt-4 border-t border-border">
+            <button className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 text-sm">
+              Edit Settings
+            </button>
+          </div>
+        </div>
+      </Tabs.Content>
     </Tabs.Root>
   </div>
-);
+  );
+};
 
 // --- MAIN PAGE COMPONENT ---
 

--- a/specs/active/fix-project-personalization.spec.md
+++ b/specs/active/fix-project-personalization.spec.md
@@ -1,0 +1,166 @@
+# Spec: Project Personalization in Chat Pipeline
+
+> **Spec ID:** FIX-PROJECT-PERSONALIZATION
+> **Status:** SPEC
+> **Created:** 2026-02-26
+> **Track:** Team B (Luci/Seshat)
+> **Issue:** Projects can be created but have no personalization or functionality applied in chat
+
+---
+
+## Problem Statement
+
+Users report: "Projects can be created but seem to have no personalization or functionality."
+
+The schema (Sprint 3.0, AGE-139) added project settings fields (`systemPrompt`, `defaultModel`, `defaultProvider`) stored in the `settings` object of the projects table. However, `chat.ts` ignores these project fields — it only reads agent-level settings (`agent.model`, `agent.provider`, `agent.instructions`).
+
+Project-level overrides should take precedence over agent-level defaults but are never applied.
+
+---
+
+## Proposed Solution
+
+Wire project settings into the chat execution pipeline so that:
+
+1. When an agent belongs to a project (`agent.projectId` is set), load the project's settings
+2. Project settings override agent-level defaults:
+   - `project.settings.systemPrompt` prepended to `agent.instructions`
+   - `project.settings.defaultProvider` overrides `agent.provider`
+   - `project.settings.defaultModel` overrides `agent.model`
+3. The UI already displays these fields (dist/templates), and packages/web now includes them too
+
+---
+
+## Sections
+
+### Section A: Project systemPrompt prepends to agent instructions
+
+**Given:** An agent with `instructions = "You are a helpful assistant."` belongs to a project with `settings.systemPrompt = "Always respond in Spanish."`
+
+**When:** A user sends a message through `chat.sendMessage`
+
+**Then:**
+- [A1] The action loads the project via `api.projects.get`
+- [A2] The system prompt combines both: `"Always respond in Spanish.\n\nYou are a helpful assistant."`
+- [A3] The combined prompt is passed to the LLM
+- [A4] Responses reflect the project-level instruction (Spanish responses)
+- [A5] If the project has no `systemPrompt`, only agent instructions are used
+- [A6] If the project has no `settings` object, only agent instructions are used
+
+### Section B: Project defaultModel/defaultProvider override agent settings
+
+**Given:** An agent with `provider = "openai"`, `model = "gpt-4o-mini"` belongs to a project with:
+- `settings.defaultProvider = "anthropic"`
+- `settings.defaultModel = "claude-sonnet-4-6"`
+
+**When:** A user sends a message through `chat.sendMessage`
+
+**Then:**
+- [B1] The action loads the project via `api.projects.get`
+- [B2] The provider `anthropic` overrides the agent's `openai`
+- [B3] The model `claude-sonnet-4-6` overrides the agent's `gpt-4o-mini`
+- [B4] The LLM call uses `anthropic/claude-sonnet-4-6` as the model key
+- [B5] Usage recording records `anthropic` as the provider
+- [B6] Usage recording records `claude-sonnet-4-6` as the model
+- [B7] If the project only sets `defaultProvider`, agent model is still used
+- [B8] If the project only sets `defaultModel`, agent provider is still used
+
+### Section C: projects.get query exists and returns project with settings
+
+**Given:** The Convex database has a projects table
+
+**When:** `api.projects.get` is called with `{ id: projectId }`
+
+**Then:**
+- [C1] The query exists in `convex/projects.ts`
+- [C2] The query accepts `{ id: v.id("projects") }` as args
+- [C3] The query returns a project object with all fields
+- [C4] The returned project includes the `settings` field if set
+- [C5] The `settings` field can contain `systemPrompt`, `defaultModel`, `defaultProvider`
+- [C6] If the project has no settings, `settings` is `undefined` or an empty object
+
+### Section D: Projects UI shows systemPrompt, defaultModel, defaultProvider fields
+
+**Given:** A user opens the projects page in the dashboard
+
+**When:** The user views or edits a project
+
+**Then:**
+- [D1] The projects page includes a "Settings" tab (dist/templates)
+- [D2] The Settings tab shows a "System Prompt" textarea
+- [D3] The System Prompt field accepts up to 2000 characters
+- [D4] The Settings tab shows a "Default Provider" dropdown
+- [D5] The Settings tab shows a "Default Model" dropdown
+- [D6] The Model dropdown is disabled when no Provider is selected
+- [D7] Changes to Provider auto-select the first Model for that provider
+- [D8] The "Save Settings" button persists changes to the database
+- [D9] (packages/web) The ProjectForm includes an expandable settings section
+- [D10] (packages/web) The ProjectDetailView Settings tab displays current settings
+- [D11] Form validation ensures required fields are present
+- [D12] Empty values mean "use agent default" for that field
+
+---
+
+## Implementation Plan
+
+1. **convex/chat.ts** (both root and templates/default):
+   - After loading the agent, check if `agent.projectId` exists
+   - If yes, load project via `ctx.runQuery(api.projects.get, { id: agent.projectId })`
+   - Extract `settings.systemPrompt`, `settings.defaultModel`, `settings.defaultProvider`
+   - Build combined system prompt: project prompt + agent instructions
+   - Use overridden provider/model for LLM call and usage recording
+
+2. **packages/web/app/routes/projects.tsx**:
+   - Add `ProjectSettings` type with `systemPrompt`, `defaultModel`, `defaultProvider`
+   - Update `Project` type to include optional `settings`
+   - Add expandable settings section to `ProjectForm`
+   - Update `ProjectDetailView` Settings tab to display settings
+   - Import `LLM_PROVIDERS` and `getModelsByProvider` for dropdowns
+
+3. **convex/projects.ts**:
+   - Verify `get` query exists (it already does)
+
+4. **Tests** (packages/cli/tests/unit/project-personalization.test.ts):
+   - Test override precedence: project > agent > defaults
+   - Test system prompt concatenation
+   - Test provider/model override
+   - Test null/undefined handling
+
+---
+
+## Edge Cases
+
+1. **Agent not in a project**: Use agent-level settings only (existing behavior)
+2. **Project exists but has no settings**: Use agent-level settings only
+3. **Project settings.partial**: Only override what's set, use agent for rest
+4. **Project with empty settings**: Treat as no settings (use agent defaults)
+5. **Agent projectId points to deleted project**: Gracefully handle, use agent defaults
+
+---
+
+## Success Criteria
+
+- [ ] All 32 assertions pass (A1-A6, B1-B8, C1-C6, D1-D12)
+- [ ] `pnpm test` passes with at least 8 new test cases
+- [ ] `pnpm build` completes without errors
+- [ ] `diff -rq dist/default/ templates/default/` shows no differences for chat.ts
+- [ ] Manual test: Create project with overrides, verify agent chat uses them
+
+---
+
+## Dependencies
+
+- **AGE-106**: Project-scoped schema (already merged)
+- **AGE-107**: File uploads (not blocking)
+- **Convex projects.get query**: Already exists
+
+---
+
+## Rollout Plan
+
+1. Deploy to development environment
+2. Create test project with overrides
+3. Send chat message through assigned agent
+4. Verify system prompt and model/provider are applied
+5. Run test suite
+6. Deploy to production


### PR DESCRIPTION
## What changed

Project-level settings now override agent-level settings in the chat pipeline.

### Problem
Projects could be created but had no functional effect — agent chat always used agent-level model/provider/instructions regardless of project settings.

### Fix
**`convex/chat.ts`** — loads project settings when `agent.projectId` is set:
- `projectDefaultProvider` → overrides `agent.provider`
- `projectDefaultModel` → overrides `agent.model`
- `projectSystemPrompt` → prepended to agent instructions

**`convex/projects.ts`** — added `get` query (needed by chat.ts)

**`dashboard/app/routes/projects.tsx`** — added systemPrompt, defaultModel, defaultProvider fields to project settings panel

### Precedence
Project settings > Agent settings > System defaults

### Q&S
- ✅ 82/82 tests + 13 new unit tests
- ✅ SpecSafe spec: 32 assertions
- ✅ 0 vulnerabilities
- ✅ dist ↔ templates in sync