### PR TITLE
fix(ts): resolve 7 TypeScript errors blocking `npx convex dev` on fresh install

### DIFF
--- a/packages/cli/dist/default/convex/mastraIntegration.ts
+++ b/packages/cli/dist/default/convex/mastraIntegration.ts
@@ -20,6 +20,7 @@ import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
+import type { MessageListInput } from "@mastra/core/agent";
 
 // Map provider name to the env var name Mastra's router expects
 function getProviderEnvKey(provider: string): string {
@@ -162,7 +163,7 @@ export const executeAgent = action({
         model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages);
+      const result = await mastraAgent.generate(conversationMessages as MessageListInput);
 
       const responseContent = result.text;
 
@@ -305,7 +306,7 @@ export const executeWorkflow = action({
  * This action lives here (Node.js runtime) so that chat.ts can remain in the
  * default Convex runtime and freely mix queries, mutations, and actions.
  */
-export const generateResponse = action({
+export const generateResponse = internalAction({
   args: {
     provider: v.string(), // AGE-137: Added provider argument
     modelKey: v.string(),
@@ -351,7 +352,7 @@ export const generateResponse = action({
       model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages);
+    const result = await mastraAgent.generate(args.messages as MessageListInput);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {

--- a/packages/cli/dist/default/convex/projects.ts
+++ b/packages/cli/dist/default/convex/projects.ts
@@ -78,7 +78,7 @@ export const getAgents = query({
     const project = await ctx.db.get(args.id);
     if (!project?.agentIds?.length) return [];
 
-    const agents: typeof import("./_generated/dataModel").Doc<"agents">[] = [];
+    const agents: Array<{ _id: string; id: string; name: string; [key: string]: unknown }> = [];
     for (const agentId of project.agentIds) {
       const agent = await ctx.db
         .query("agents")

--- a/packages/cli/dist/default/convex/schema.ts
+++ b/packages/cli/dist/default/convex/schema.ts
@@ -18,10 +18,12 @@ export default defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
     userId: v.optional(v.string()),
+    projectId: v.optional(v.id("projects")),
   })
     .index("byAgentId", ["id"])
     .index("byUserId", ["userId"])
-    .index("byIsActive", ["isActive"]),
+    .index("byIsActive", ["isActive"])
+    .index("byProjectId", ["projectId"]),
 
   // Conversation threads
   threads: defineTable({

--- a/packages/cli/dist/default/convex/sessions.ts
+++ b/packages/cli/dist/default/convex/sessions.ts
@@ -150,11 +150,11 @@ export const updateStatus = mutation({
     }
     
     const updates: {
-      status: string;
+      status: "active" | "paused" | "completed" | "error";
       lastActivityAt: number;
       completedAt?: number;
     } = {
-      status: args.status,
+      status: args.status as "active" | "paused" | "completed" | "error",
       lastActivityAt: Date.now(),
     };
 

--- a/packages/cli/templates/default/convex/mastraIntegration.ts
+++ b/packages/cli/templates/default/convex/mastraIntegration.ts
@@ -20,6 +20,7 @@ import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
+import type { MessageListInput } from "@mastra/core/agent";
 
 // Map provider name to the env var name Mastra's router expects
 function getProviderEnvKey(provider: string): string {
@@ -162,7 +163,7 @@ export const executeAgent = action({
         model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages);
+      const result = await mastraAgent.generate(conversationMessages as MessageListInput);
 
       const responseContent = result.text;
 
@@ -305,7 +306,7 @@ export const executeWorkflow = action({
  * This action lives here (Node.js runtime) so that chat.ts can remain in the
  * default Convex runtime and freely mix queries, mutations, and actions.
  */
-export const generateResponse = action({
+export const generateResponse = internalAction({
   args: {
     provider: v.string(), // AGE-137: Added provider argument
     modelKey: v.string(),
@@ -351,7 +352,7 @@ export const generateResponse = action({
       model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages);
+    const result = await mastraAgent.generate(args.messages as MessageListInput);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {

--- a/packages/cli/templates/default/convex/projects.ts
+++ b/packages/cli/templates/default/convex/projects.ts
@@ -78,7 +78,7 @@ export const getAgents = query({
     const project = await ctx.db.get(args.id);
     if (!project?.agentIds?.length) return [];
 
-    const agents: typeof import("./_generated/dataModel").Doc<"agents">[] = [];
+    const agents: Array<{ _id: string; id: string; name: string; [key: string]: unknown }> = [];
     for (const agentId of project.agentIds) {
       const agent = await ctx.db
         .query("agents")

--- a/packages/cli/templates/default/convex/schema.ts
+++ b/packages/cli/templates/default/convex/schema.ts
@@ -18,10 +18,12 @@ export default defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
     userId: v.optional(v.string()),
+    projectId: v.optional(v.id("projects")),
   })
     .index("byAgentId", ["id"])
     .index("byUserId", ["userId"])
-    .index("byIsActive", ["isActive"]),
+    .index("byIsActive", ["isActive"])
+    .index("byProjectId", ["projectId"]),
 
   // Conversation threads
   threads: defineTable({

--- a/packages/cli/templates/default/convex/sessions.ts
+++ b/packages/cli/templates/default/convex/sessions.ts
@@ -150,11 +150,11 @@ export const updateStatus = mutation({
     }
     
     const updates: {
-      status: string;
+      status: "active" | "paused" | "completed" | "error";
       lastActivityAt: number;
       completedAt?: number;
     } = {
-      status: args.status,
+      status: args.status as "active" | "paused" | "completed" | "error",
       lastActivityAt: Date.now(),
     };
 


### PR DESCRIPTION
## Problem
Users hit 7 TS errors on \`npx convex dev\` after \`agentforge create\`:

1. **chat.ts:186** — \`agent.projectId\` used but not in schema → added to agents table
2. **heartbeatActions.ts:28** — \`internal.mastraIntegration.generateResponse\` missing → was \`action\`, changed to \`internalAction\`
3. **mastraIntegration.ts:165,354** — \`generate()\` call missing \`MessageListInput\` cast (removed in PR #109 BYOK refactor)
4. **projects.ts:81** — \`Doc<"agents">\` inline import fails before \`convex dev\` generates types → replaced with explicit type
5. **sessions.ts:165** — \`status: string\` not assignable to union → typed as \`"active" | "paused" | "completed" | "error"\`

## Q&S
- ✅ 107/107 tests
- ✅ dist ↔ templates in sync
- ✅ 0 vulnerabilities