### PR TITLE
fix(ts): chat.ts api→internal for generateResponse; MessageListInput→MessageList

### DIFF
--- a/packages/cli/dist/default/convex/chat.ts
+++ b/packages/cli/dist/default/convex/chat.ts
@@ -233,7 +233,7 @@ export const sendMessage = action({
         ? `${projectSystemPrompt}\n\n${baseInstructions}`
         : baseInstructions;
 
-      const result = await ctx.runAction(api.mastraIntegration.generateResponse, {
+      const result = await ctx.runAction(internal.mastraIntegration.generateResponse, {
         provider, // AGE-137: Pass provider for BYOK
         modelKey: `${provider}/${modelId}`,
         instructions,

--- a/packages/cli/dist/default/convex/mastraIntegration.ts
+++ b/packages/cli/dist/default/convex/mastraIntegration.ts
@@ -20,7 +20,7 @@ import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
-import type { MessageListInput } from "@mastra/core/agent";
+import type { MessageList } from "@mastra/core/agent";
 
 // Map provider name to the env var name Mastra's router expects
 function getProviderEnvKey(provider: string): string {
@@ -163,7 +163,7 @@ export const executeAgent = action({
         model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages as MessageListInput);
+      const result = await mastraAgent.generate(conversationMessages as MessageList);
 
       const responseContent = result.text;
 
@@ -352,7 +352,7 @@ export const generateResponse = internalAction({
       model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages as MessageListInput);
+    const result = await mastraAgent.generate(args.messages as MessageList);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {

--- a/packages/cli/templates/default/convex/chat.ts
+++ b/packages/cli/templates/default/convex/chat.ts
@@ -233,7 +233,7 @@ export const sendMessage = action({
         ? `${projectSystemPrompt}\n\n${baseInstructions}`
         : baseInstructions;
 
-      const result = await ctx.runAction(api.mastraIntegration.generateResponse, {
+      const result = await ctx.runAction(internal.mastraIntegration.generateResponse, {
         provider, // AGE-137: Pass provider for BYOK
         modelKey: `${provider}/${modelId}`,
         instructions,

--- a/packages/cli/templates/default/convex/mastraIntegration.ts
+++ b/packages/cli/templates/default/convex/mastraIntegration.ts
@@ -20,7 +20,7 @@ import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { Agent } from "@mastra/core/agent";
-import type { MessageListInput } from "@mastra/core/agent";
+import type { MessageList } from "@mastra/core/agent";
 
 // Map provider name to the env var name Mastra's router expects
 function getProviderEnvKey(provider: string): string {
@@ -163,7 +163,7 @@ export const executeAgent = action({
         model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages as MessageListInput);
+      const result = await mastraAgent.generate(conversationMessages as MessageList);
 
       const responseContent = result.text;
 
@@ -352,7 +352,7 @@ export const generateResponse = internalAction({
       model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages as MessageListInput);
+    const result = await mastraAgent.generate(args.messages as MessageList);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {


### PR DESCRIPTION
Two follow-up TS errors from PR #112:

1. `chat.ts:236` — `generateResponse` moved to `internalAction` in #112 but `chat.ts` still called it via `api.*`. Fixed to `internal.mastraIntegration.generateResponse`.
2. `mastraIntegration.ts:23` — `MessageListInput` does not exist in `@mastra/core/agent`; correct export is `MessageList`. Fixed import + both cast sites.

✅ 107/107 tests, dist ↔ templates in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal integration routing and type definitions for the Mastra agent integration to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->