### PR TITLE
fix(ts): Mastra 1.8.0 import paths — Agent from core, MessageListInput from agent/message-list

### DIFF
--- a/packages/cli/dist/default/convex/chat.ts
+++ b/packages/cli/dist/default/convex/chat.ts
@@ -13,7 +13,7 @@
  */
 import { action, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 
 // Explicit return type shared by sendMessage and startNewChat.

--- a/packages/cli/dist/default/convex/mastraIntegration.ts
+++ b/packages/cli/dist/default/convex/mastraIntegration.ts
@@ -19,8 +19,8 @@
 import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
-import { Agent } from "@mastra/core/agent";
-import type { MessageList } from "@mastra/core/agent";
+import { Agent } from "@mastra/core";
+import type { MessageListInput } from "@mastra/core/agent/message-list";
 
 // Map provider name to the env var name Mastra's router expects
 function getProviderEnvKey(provider: string): string {
@@ -163,7 +163,7 @@ export const executeAgent = action({
         model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages as MessageList);
+      const result = await mastraAgent.generate(conversationMessages as unknown as MessageListInput);
 
       const responseContent = result.text;
 
@@ -352,7 +352,7 @@ export const generateResponse = internalAction({
       model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages as MessageList);
+    const result = await mastraAgent.generate(args.messages as unknown as MessageListInput);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {

--- a/packages/cli/templates/default/convex/chat.ts
+++ b/packages/cli/templates/default/convex/chat.ts
@@ -13,7 +13,7 @@
  */
 import { action, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 
 // Explicit return type shared by sendMessage and startNewChat.

--- a/packages/cli/templates/default/convex/mastraIntegration.ts
+++ b/packages/cli/templates/default/convex/mastraIntegration.ts
@@ -19,8 +19,8 @@
 import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
-import { Agent } from "@mastra/core/agent";
-import type { MessageList } from "@mastra/core/agent";
+import { Agent } from "@mastra/core";
+import type { MessageListInput } from "@mastra/core/agent/message-list";
 
 // Map provider name to the env var name Mastra's router expects
 function getProviderEnvKey(provider: string): string {
@@ -163,7 +163,7 @@ export const executeAgent = action({
         model: mastraModel,
       });
 
-      const result = await mastraAgent.generate(conversationMessages as MessageList);
+      const result = await mastraAgent.generate(conversationMessages as unknown as MessageListInput);
 
       const responseContent = result.text;
 
@@ -352,7 +352,7 @@ export const generateResponse = internalAction({
       model: mastraModel,
     });
 
-    const result = await mastraAgent.generate(args.messages as MessageList);
+    const result = await mastraAgent.generate(args.messages as unknown as MessageListInput);
 
     // AI SDK v5 renamed promptTokens→inputTokens, completionTokens→outputTokens
     return {


### PR DESCRIPTION
Third round of TS init fixes — root-caused by inspecting actual @mastra/core@1.8.0 package exports.

| Error | Root cause | Fix |
|---|---|---|
| Cannot find name 'internal' in chat.ts | Only 'api' was imported, not 'internal' | Added 'internal' to import |
| '@mastra/core/agent' has no exported member 'Agent' | That subpath does not exist in 1.8.0 | Import Agent from '@mastra/core' |
| MessageListInput not found in '@mastra/core/agent' | Must come from '@mastra/core/agent/message-list' | Fixed import path |
| cast via as MessageList broke | MessageList is a class — plain object array does not overlap | Cast via unknown as MessageListInput |

107/107 tests, dist and templates in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type handling for Mastra SDK compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->