### PR TITLE
docs: enforce SpecSafe-first + CLI-first in AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,3 +208,53 @@ fix/AGE-{number}-{short-description}    →  main
 - **Concurrent Dev Plan:** `CONCURRENT_PLAN.md` (this repo)
 - **Project State:** `PROJECT_STATE.md` (this repo)
 - **GitHub:** https://github.com/Agentic-Engineering-Agency/agentforge
+
+---
+
+## 🛡️ MANDATORY DEVELOPMENT PROCESS
+
+### Rule 1: SpecSafe-First (NON-NEGOTIABLE)
+**Every implementation must follow this exact order:**
+
+1. **Write tests FIRST** — before any code exists, before planning implementation details
+2. **Implement** — write the feature/fix only after tests are written
+3. **Run tests** — `pnpm test`
+4. **Fix failures** — if any test fails, dev agents must fix before proceeding
+5. **Never skip** — no exceptions, no "I'll add tests later"
+
+```bash
+# Correct order
+specsafe new my-feature    # 1. Create spec
+# ... write tests in spec ...
+pnpm test                  # 2. Watch tests fail (TDD)
+# ... implement ...
+pnpm test                  # 3. Tests must pass
+```
+
+### Rule 2: Research Official Docs (ALWAYS)
+APIs change fast. Before implementing ANYTHING:
+- **Mastra**: https://mastra.ai/docs (check current version — breaking changes are common)
+- **Convex**: https://docs.convex.dev (runtime rules change)
+- **Never** rely on memory or prior sessions — always fetch current docs
+
+### Rule 3: CLI-First Development
+Every new feature must be implemented in this order:
+1. **CLI first** — `agentforge <command>` (testable, no UI dependency)
+2. **Dashboard second** — replicate the same logic in the local web UI
+
+The CLI is the source of truth. The dashboard is a view layer.
+
+### Rule 4: Convex Runtime Boundaries
+- `"use node"` files: ONLY `action` / `internalAction` functions (no queries, no mutations)
+- Default runtime: queries + mutations + non-Node actions
+- Never mix runtimes in the same file
+
+### Rule 5: Mastra 1.8.0 Model Config (BYOK)
+Use `OpenAICompatibleConfig` — never magic model strings:
+```typescript
+// ✅ Correct
+new Agent({ model: { providerId: 'openai', modelId: 'gpt-4.1', apiKey } })
+
+// ❌ Wrong — Mastra 1.8.0 does NOT strip provider prefix before calling API
+new Agent({ model: 'openai/gpt-4.1' })
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,79 @@ pnpm typecheck         # TypeScript check
 specsafe status        # Show SpecSafe project status
 specsafe list          # List all specs
 ```
+
+---
+
+## 🛡️ MANDATORY DEVELOPMENT PROCESS
+
+> These rules apply to ALL agents, ALL sprints, ALL sessions. No exceptions.
+
+### SpecSafe-First (NON-NEGOTIABLE)
+
+**Order of operations — every time, no shortcuts:**
+
+| Step | Action |
+|------|--------|
+| 1 | **Write tests first** — before any implementation |
+| 2 | **Implement** — only after tests exist |
+| 3 | **Run `pnpm test`** — all tests must pass |
+| 4 | **Fix failures** — if tests fail, fix before proceeding |
+
+```bash
+# TDD workflow
+specsafe new <feature>   # Create spec
+# write test expectations
+pnpm test                # Watch fail (red)
+# implement
+pnpm test                # Must be green before PR
+```
+
+### Research Official Docs First
+
+Before implementing ANYTHING involving Mastra, Convex, or any external dependency:
+
+1. **Read the current docs** — APIs break between minor versions
+2. **Check for breaking changes** — especially Mastra (updates weekly)
+3. **Never assume from prior context** — always verify
+
+- Mastra: https://mastra.ai/docs
+- Convex: https://docs.convex.dev
+- @mastra/s3 (R2): https://mastra.ai/reference/workspace/s3-filesystem
+
+### CLI-First Development
+
+Every feature: **CLI first → dashboard second**
+
+```bash
+agentforge <command>   # 1. Implement + test here
+# then replicate in dashboard/app/routes/...
+```
+
+### Mastra 1.8.0 BYOK — OpenAICompatibleConfig
+
+```typescript
+// ✅ Use OpenAICompatibleConfig (official API)
+new Agent({
+  model: {
+    providerId: provider,                    // 'openai' | 'anthropic' | 'openrouter'
+    modelId:    getBaseModelId(provider, id), // ALWAYS strip provider prefix!
+    apiKey,
+    url: getProviderBaseUrl(provider),       // needed for OpenRouter, Mistral, etc.
+  }
+})
+
+// ❌ Never use magic strings — Mastra 1.8.0 does not strip the prefix
+// 'openai/gpt-4.1' → OpenAI API receives 'openai/gpt-4.1' → 404
+// 'openrouter/auto' + provider 'openrouter' → 'openrouter/openrouter/auto' → 400
+```
+
+### Convex Runtime Rules
+
+```typescript
+// "use node" files: ONLY actions/internalActions
+// Default runtime: queries + mutations + regular actions
+
+// ✅ Correct split
+// chat.ts (default) — queries, mutations, actions
+// chatActions.ts ("use node") — Node.js-dependent internalActions
+```


### PR DESCRIPTION
Updates AGENTS.md and CLAUDE.md with mandatory development rules.

## Changes

**Rule 1: SpecSafe-First** — tests before implementation, always
**Rule 2: Research Official Docs** — Mastra/Convex change fast, always check current docs
**Rule 3: CLI-First Development** — every feature CLI first, dashboard second  
**Rule 4: Convex Runtime Boundaries** — `"use node"` only for actions
**Rule 5: Mastra 1.8.0 BYOK** — `OpenAICompatibleConfig` not magic strings

Closes AGE-155 · Closes AGE-156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development process guidelines with mandatory workflow specifications, testing requirements, and best practices for framework configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->