### PR TITLE
docs: Convex init mandatory + honest confirmed-vs-assumed status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,43 @@ agentforge chat <agent-id>   # Test chat CLI
 **Dashboard:** http://localhost:3000 (run `agentforge dashboard --dir /tmp/agentforge-test/agentforge-test`)
 
 Test every feature against this deployment before shipping.
+
+---
+
+## ⚠️ CONVEX MUST BE INITIALIZED BEFORE ANY TESTING
+
+**You cannot test anything without a live Convex deployment.** Unit tests mock Convex — they do NOT verify real behavior. Every feature must be tested against a real deployment.
+
+### Setup (required before first test)
+```bash
+cd <your-project>
+npx convex dev --once        # Deploy schema + functions to Convex cloud
+# Requires: Convex account + auth (~/.convex/config.json)
+```
+
+### Current Test Deployment
+```
+Dir:        /tmp/agentforge-test/agentforge-test
+Deployment: watchful-chipmunk-946.convex.cloud
+Dashboard:  agentforge dashboard --dir /tmp/agentforge-test/agentforge-test
+```
+
+### What "Working" Actually Means
+Do NOT mark a feature as working unless you have:
+1. Run `npx convex dev --once` (or equivalent)
+2. Called the actual CLI command or Convex function
+3. Received a real (non-mock) response
+4. Documented the exact command + output
+
+**Confirmed working (real Convex calls, 2026-02-27):**
+- `executeAgent` → received real LLM response ✅
+- `chat.sendMessage` → received real LLM response ✅
+- `apiKeys.create` → key stored, used successfully by executeAgent ✅
+- `agents.list` → returned real DB record ✅
+
+**NOT confirmed (connected but CRUD not fully tested):**
+- cron create/run, mcp add/test, skills install/create
+- agents edit/delete/enable/disable (CLI interactive paths)
+- agentforge agents create (interactive CLI — not tested)
+- All dashboard pages (code has useQuery hooks, browser never opened)
+- projects, sessions, threads (never tested end-to-end)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,3 +191,44 @@ Dashboard:   http://localhost:3000
 ```
 
 **Every feature must be tested against this deployment before PR.**
+
+---
+
+## ⚠️ CONVEX INIT IS MANDATORY — NO EXCEPTIONS
+
+You cannot test any feature without a running Convex deployment. Mocked unit tests do NOT count as verification.
+
+```bash
+# Required before any testing
+npx convex dev --once
+
+# Then test the feature for real:
+npx convex run agents:list
+agentforge chat <agent-id>
+# etc.
+```
+
+### Honesty Standard for "Working" Status
+A feature is only marked ✅ working if ALL of these are true:
+1. `npx convex dev --once` ran successfully
+2. The actual CLI command or Convex function was called against the live deployment
+3. A real (non-mock, non-empty) response was returned
+4. The command + output is documented
+
+### Confirmed Working (2026-02-27, real Convex)
+| Feature | Command | Result |
+|---------|---------|--------|
+| Agent execution | `npx convex run mastraIntegration:executeAgent` | Real OpenAI response ✅ |
+| Chat | `npx convex run chat:sendMessage` | Real OpenAI response ✅ |
+| API key storage | `npx convex run apiKeys:create` | Key stored + used ✅ |
+| Agents list | `agentforge agents list` | Real DB record ✅ |
+| File upload | `agentforge files upload` | BROKEN — metadata only ❌ |
+| Chat CLI interactive | `agentforge chat <id>` | BROKEN — exits immediately ❌ |
+
+### NOT Confirmed (Do Not Assume Working)
+- cron CRUD beyond `list`
+- mcp add / connection test
+- skills install / create
+- agents create (interactive CLI), edit, delete, enable, disable
+- All dashboard pages in browser (code exists, never opened)
+- projects, sessions, threads end-to-end


### PR DESCRIPTION
Two critical clarifications to AGENTS.md and CLAUDE.md:

**1. Convex MUST be initialized before any testing**
npx convex dev --once is required. Unit tests mock Convex — they do NOT verify real behavior.

**2. Honest status table**
Documents exactly what was confirmed with real Convex calls vs what is assumed from code inspection.

Confirmed ✅: executeAgent, chat.sendMessage, apiKeys.create, agents.list
NOT confirmed ❌: cron/mcp/skills CRUD, agents create/edit/delete interactive CLI, all dashboard pages in browser, projects/sessions/threads end-to-end