### PR TITLE
docs: framework-only scope + clean rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,169 +1,100 @@
 # AGENTS.md — AgentForge AI Development Team
 
-> **For AI coding assistants:** Read `CLAUDE.md` for the full project context, rules, and SpecSafe workflow.  
-> This file documents the human+AI team structure and mandatory development rules.
+> **For AI coding assistants:** Read `CLAUDE.md` for the full project context, rules, and SpecSafe workflow.
+
+---
+
+## 🚨 SCOPE (Read first)
+
+**This repo is the complete product.** CLI + local dashboard. That's it.
+
+- `packages/cli/` — the CLI (`agentforge` command)
+- `packages/core/` — shared types and utilities
+- `packages/cli/dist/default/` — local dashboard + Convex functions (what `agentforge create` scaffolds)
+- `packages/cli/templates/default/` — must always be identical to `dist/default/`
+
+Everything is built and tested here. Auth, billing, and cloud hosting are future concerns — do not implement them now.
 
 ---
 
 ## 👥 Team Structure
 
-### Track A: Architecture & Infrastructure (Lalo + Puck)
-- **AI Agent:** Puck (Claude Code, claude-opus-4-6 lead / claude-sonnet-4-6 teammates)
-- **Role:** Architecture, DB schema, Mastra backend, Convex infrastructure
-- **Owns:** `convex/schema.ts`, `convex/workflows/`, `docs/DESIGN-*.md`
+### Track A: Architecture & Infrastructure
+- DB schema, Mastra backend, Convex functions
+- Owns: `convex/schema.ts`, `convex/workflows/`, design docs
 
-### Track B: Core Engine + Product (Luci + Seshat)
-- **AI Agent:** Seshat (Claude Code, claude-opus-4-6 lead / claude-sonnet-4-6 teammates)
-- **Role:** CLI, dashboard, Mastra integration, file system, skills
-- **Owns:** `packages/cli/`, `packages/core/`, `convex/mastraIntegration.ts`
+### Track B: Core Engine + Product
+- CLI commands, local dashboard, Mastra integration
+- Owns: `packages/cli/`, `packages/core/`, `convex/mastraIntegration.ts`
 
 ---
 
-## 🛡️ MANDATORY DEVELOPMENT RULES (NON-NEGOTIABLE)
+## 🛡️ RULES (NON-NEGOTIABLE)
 
-> All rules apply to ALL agents, ALL tracks, ALL sprints. Zero exceptions.
+### 1 · Codebase Audit First
+Before writing any code, test the feature against the live Convex deployment. Does it exist? Is it broken? Is it a stub? Document findings before touching anything.
 
-### Rule 1: Codebase Audit First
-Before building ANY feature, **audit the codebase**:
-1. Does it already exist? → Test it against the live Convex deployment
-2. Is it broken? → Fix it (file a bug issue first)
-3. Is it a stub/placeholder? → Note it, implement properly
-4. Only after audit: proceed to SpecSafe workflow
-
-### Rule 2: SpecSafe-First (Tests Before Code)
+### 2 · SpecSafe-First
 ```
-1. Write tests (specsafe new <feature>)
-2. Watch tests FAIL (red — proves tests are real)
-3. Implement
-4. Run tests → must be GREEN
-5. If failing → fix before ANY other work
-6. Never skip, never "add tests later"
+Write tests → watch them FAIL → implement → tests GREEN → ship
 ```
+Never write code before tests. Never ship with failing tests.
 
-### Rule 3: Research Official Docs Before Every Sprint
-Mastra and Convex update weekly. **Never implement from memory.**
-- **Mastra:** https://mastra.ai/docs (Workspace, Skills, Agent, Workflow APIs)
-- **Convex:** https://docs.convex.dev (runtime rules, file storage, HTTP actions)
-- **Mastra Workspace Skills:** https://mastra.ai/docs/workspace/skills
-- **Mastra S3Filesystem (R2):** https://mastra.ai/reference/workspace/s3-filesystem
-- **Mastra Filesystem:** https://mastra.ai/docs/workspace/filesystem
-- Always check: are there breaking changes since last sprint?
+### 3 · Research Official Docs Before Every Sprint
+APIs change constantly. Read before implementing:
+- Mastra: https://mastra.ai/docs
+- Convex: https://docs.convex.dev
+- Mastra Workspace / Skills: https://mastra.ai/docs/workspace/skills
+- Convex file storage: https://docs.convex.dev/file-storage
+- Convex HTTP actions: https://docs.convex.dev/functions/http-actions
 
-### Rule 4: CLI First → Dashboard Second
-Every feature must be implemented in this exact order:
-1. **CLI command** (`agentforge <command>`) — testable, no UI dependency
-2. **Dashboard route** — replicate the same logic in the web UI
+### 4 · CLI First → Local Dashboard Second
+1. CLI command → tested against live Convex
+2. Local dashboard (`dist/default/`) → view layer only
 
-The CLI is the source of truth. The dashboard is a view layer only.
+### 5 · Mastra-Native
+- Skills = SKILL.md folders (agentskills.io standard) — never `createTool` arrays
+- Use `Agent.stream()` / `Agent.generate()` — never raw AI SDK calls
+- Use `OpenAICompatibleConfig { providerId, modelId, apiKey }` — never magic model strings
+- Use Mastra Workflow API for orchestration
 
-### Rule 5: Mastra-Native (Not createTool)
-- Use `Workspace`, `LocalFilesystem`, `S3Filesystem` for file operations
-- Use **SKILL.md standard** (agentskills.io) for skills — NOT `createTool` directly
-- Use `Agent.generate()` / `Agent.stream()` — NOT raw AI SDK calls
-- Use Mastra Workflow API for multi-agent orchestration
-- Use `OpenAICompatibleConfig { providerId, modelId, apiKey }` for BYOK — NOT magic strings
+### 6 · Convex Runtime Boundaries
+- `"use node"` files: only `action` / `internalAction`
+- Default runtime: queries + mutations
+- Never call `internal.*` via `api.*`
 
-### Rule 6: Convex Runtime Boundaries
-```
-"use node" files:     ONLY action / internalAction functions
-Default runtime:      queries + mutations + standard actions
-NEVER mix runtimes in one file.
-NEVER call internal.* via api.* — use ctx.runQuery(internal.module.fn)
-```
+### 7 · No Hardcoded Model Lists
+Fetch from provider API when key is added → cache in DB → UI reads DB. Static fallback only if fetch fails.
 
-### Rule 7: No Hardcoded Model Lists
-Dynamic only. When API key is added → fetch available models from provider API → cache in DB → populate UI from DB. A safe static fallback is acceptable only if the API fetch fails.
+### 8 · No Fake Implementations
+No placeholders shipped. File upload stores bytes. Streaming streams tokens. Skills are SKILL.md folders.
 
-### Rule 8: No Fake Implementations
-- No "placeholder", "stub", or "coming soon" implementations in shipped code
-- File upload MUST actually store file content (Convex storage or R2) — never metadata-only
-- Streaming MUST actually stream — never fall back to full generation silently
-- Skills MUST use SKILL.md filesystem format — never hardcoded arrays in UI
+### 9 · QA + Security After Every Sprint
+`pnpm test` all green → validate all mutation inputs → live test on `watchful-chipmunk-946` → document results.
 
-### Rule 9: Quality & Security Check After Every Sprint
-After every sprint iteration (every PR merge):
-1. **QA check:** Run `pnpm test` — all must pass
-2. **Security check:** Review all new mutations for input validation
-3. **Live test:** Test the feature against the real Convex deployment (`watchful-chipmunk-946`)
-4. **Audit report:** Document what was tested and the result
+### 10 · dist/default ≡ templates/default
+Any change to `dist/default/` must be made identically in `templates/default/`. Always.
 
-### Rule 10: File Storage Standard
-- **Dev:** Convex file storage (`ctx.storage.generateUploadUrl()`)
-- **Prod:** Mastra S3Filesystem → Cloudflare R2
-- Never store file content as base64 strings in DB records
+### 11 · Claude Code Agent Teams (Preferred)
+Z.ai is configured. Try `claude --dangerously-skip-permissions --print "..."` first. Fall back only if it actually fails.
 
 ---
 
-## 🏗️ AgentForge Vision
-
-AgentForge = OpenClaw-style agent platform, but:
-- **Smaller** — focused on developer/enterprise use case
-- **Safer** — RBAC, encrypted keys, audit logs from day 1
-- **Mastra-native** — built on Mastra + Convex, not custom LLM plumbing
-- **CLI-primary** — everything works from the terminal first
-
----
-
-## 🔧 Useful Commands
+## ⚠️ Convex Must Be Initialized Before Testing
 
 ```bash
-pnpm test                    # Run all tests (must pass before any PR)
-pnpm build                   # Build all packages
-pnpm typecheck               # TypeScript check
-specsafe new <feature>       # Create SpecSafe spec (ALWAYS do this first)
-specsafe list                # List all specs
-npx convex dev --once        # Deploy Convex functions
-agentforge agents list       # Test agents CLI
-agentforge chat <agent-id>   # Test chat CLI
+npx convex dev --once   # run inside /tmp/agentforge-test/agentforge-test
 ```
+
+Unit tests mock Convex. Real verification requires a live deployment.
+
+**Confirmed working (2026-02-27):** `executeAgent`, `chat.sendMessage`, `apiKeys.create`, `agents.list`
 
 ---
 
 ## 📦 Live Test Deployment
 
-**Project:** agentforge-test  
-**Deployment:** `watchful-chipmunk-946.convex.cloud`  
-**Team:** AgenticEngineering  
-**Dashboard:** http://localhost:3000 (run `agentforge dashboard --dir /tmp/agentforge-test/agentforge-test`)
-
-Test every feature against this deployment before shipping.
-
----
-
-## ⚠️ CONVEX MUST BE INITIALIZED BEFORE ANY TESTING
-
-**You cannot test anything without a live Convex deployment.** Unit tests mock Convex — they do NOT verify real behavior. Every feature must be tested against a real deployment.
-
-### Setup (required before first test)
-```bash
-cd <your-project>
-npx convex dev --once        # Deploy schema + functions to Convex cloud
-# Requires: Convex account + auth (~/.convex/config.json)
 ```
-
-### Current Test Deployment
-```
-Dir:        /tmp/agentforge-test/agentforge-test
 Deployment: watchful-chipmunk-946.convex.cloud
-Dashboard:  agentforge dashboard --dir /tmp/agentforge-test/agentforge-test
+Dir:        /tmp/agentforge-test/agentforge-test
 ```
-
-### What "Working" Actually Means
-Do NOT mark a feature as working unless you have:
-1. Run `npx convex dev --once` (or equivalent)
-2. Called the actual CLI command or Convex function
-3. Received a real (non-mock) response
-4. Documented the exact command + output
-
-**Confirmed working (real Convex calls, 2026-02-27):**
-- `executeAgent` → received real LLM response ✅
-- `chat.sendMessage` → received real LLM response ✅
-- `apiKeys.create` → key stored, used successfully by executeAgent ✅
-- `agents.list` → returned real DB record ✅
-
-**NOT confirmed (connected but CRUD not fully tested):**
-- cron create/run, mcp add/test, skills install/create
-- agents edit/delete/enable/disable (CLI interactive paths)
-- agentforge agents create (interactive CLI — not tested)
-- All dashboard pages (code has useQuery hooks, browser never opened)
-- projects, sessions, threads (never tested end-to-end)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,231 +4,133 @@
 
 ---
 
-## 🎯 What is AgentForge?
+## What is AgentForge?
 
-AgentForge is an AI agent platform similar to OpenClaw, but:
-- **Smaller** — focused, not trying to cover every use case
-- **Safer** — encrypted key storage, RBAC, audit logs from the start
-- **Mastra-native** — the entire agent runtime is built on Mastra + Convex
-- **CLI-primary** — every feature works from the terminal first
+An AI agent framework: CLI + local dashboard, built on Mastra + Convex. Self-hosted, developer-focused, secure by default.
 
-**NOT allowed:**
-- Raw AI SDK calls bypassing Mastra
-- Hardcoded model lists
-- Fake/stub implementations shipped as real features
-- `createTool` pattern for skills (use SKILL.md standard)
+This repo is the complete product. CLI, local dashboard, Convex functions — all here. Auth, billing, and hosting are future concerns. Do not implement them now.
 
 ---
 
-## 🛡️ MANDATORY RULES — READ BEFORE WRITING ANY CODE
+## 🚨 RULES — Read Before Writing Any Code
 
-### 1. Codebase Audit First
-Before implementing: search the codebase. Does it exist? Is it broken? Is it a placeholder?
-Test against the live deployment: `watchful-chipmunk-946.convex.cloud`
+### 1 · Audit first
+Before implementing: search the codebase, test against `watchful-chipmunk-946.convex.cloud`. Does it exist? Is it broken? Is it a stub? Document what you find.
 
-### 2. SpecSafe-First
+### 2 · SpecSafe-first
 ```bash
-specsafe new <feature>   # Step 1: Write spec + tests
-# Step 2: Watch tests fail (proves tests work)
-# Step 3: Implement
-pnpm test                # Step 4: Must be GREEN
-# Step 5: If failing — fix NOW, before anything else
+# Step 1: write tests
+# Step 2: watch them fail (proves tests are real)
+# Step 3: implement
+pnpm test   # Step 4: must be GREEN
+# Step 5: if failing — fix NOW, before anything else
 ```
-**Never write code before tests. Never ship with failing tests.**
 
-### 3. Research Official Docs (Every Sprint)
-APIs change constantly. Read before implementing:
-- Mastra Workspace: https://mastra.ai/docs/workspace/overview
-- Mastra Skills (SKILL.md): https://mastra.ai/docs/workspace/skills
-- Mastra Filesystem: https://mastra.ai/docs/workspace/filesystem
-- Mastra S3/R2: https://mastra.ai/reference/workspace/s3-filesystem
-- Convex: https://docs.convex.dev
-- Convex File Storage: https://docs.convex.dev/file-storage
-- Convex HTTP Actions (SSE): https://docs.convex.dev/functions/http-actions
+### 3 · Research official docs before every sprint
+```
+Mastra:                 https://mastra.ai/docs
+Mastra Skills:          https://mastra.ai/docs/workspace/skills
+Mastra Workspace:       https://mastra.ai/docs/workspace/overview
+Mastra S3/R2:           https://mastra.ai/reference/workspace/s3-filesystem
+Convex:                 https://docs.convex.dev
+Convex file storage:    https://docs.convex.dev/file-storage
+Convex HTTP actions:    https://docs.convex.dev/functions/http-actions
+```
 
-### 4. CLI First → Dashboard Second
-Every new feature:
-1. `agentforge <command>` — implement + test in CLI
-2. Dashboard route — replicate same logic in UI
-Never implement dashboard-only features.
+### 4 · CLI first → local dashboard second
+1. `agentforge <command>` — implemented and tested
+2. `packages/cli/dist/default/` dashboard — same logic as UI
 
-### 5. Mastra-Native APIs (Mandatory Patterns)
+### 5 · Mastra-native patterns
 
-**BYOK Model Config — ALWAYS use OpenAICompatibleConfig:**
+**BYOK — always OpenAICompatibleConfig:**
 ```typescript
-// ✅ Correct (v0.10.0+)
+// ✅ Correct
 new Agent({
   model: {
-    providerId: provider,                      // 'openai' | 'anthropic' | 'openrouter'
-    modelId: getBaseModelId(provider, modelId), // strip provider prefix!
+    providerId: provider,
+    modelId: getBaseModelId(provider, modelId),
     apiKey,
-    url: getProviderBaseUrl(provider),          // for OpenRouter/Mistral/etc
+    url: getProviderBaseUrl(provider),
   }
 })
-
-// ❌ Wrong — Mastra 1.8.0 does NOT strip prefix → API gets 'openai/gpt-4.1' → 404
+// ❌ Wrong — Mastra 1.8+ does not strip provider prefix
 new Agent({ model: 'openai/gpt-4.1' })
 ```
 
-**Workspace + Skills (SKILL.md standard):**
-```typescript
-import { Workspace, LocalFilesystem } from '@mastra/core/workspace'
-import { S3Filesystem } from '@mastra/s3'
-
-const workspace = new Workspace({
-  filesystem: process.env.AGENTFORGE_FILESYSTEM === 'r2'
-    ? new S3Filesystem({ bucket, region: 'auto', endpoint, accessKeyId, secretAccessKey })
-    : new LocalFilesystem({ basePath: './workspace' }),
-  skills: ['/skills'],  // SKILL.md folders, NOT createTool
-})
+**Skills — SKILL.md folders, never createTool:**
+```
+skills/my-skill/
+  SKILL.md        ← metadata + instructions
+  references/     ← supporting docs
+  scripts/        ← executables
+  assets/         ← images / files
 ```
 
-**Skills must be SKILL.md folders (agentskills.io spec), NOT createTool:**
-```
-/skills/my-skill/
-  SKILL.md          ← metadata + instructions
-  references/       ← supporting docs
-  scripts/          ← executable scripts
-  assets/           ← images/files
-```
-
-**Streaming (use Agent.stream(), not Agent.generate()):**
+**Streaming — Agent.stream(), not Agent.generate():**
 ```typescript
 const stream = await agent.stream(messages)
-// Use Convex HTTP action for SSE delivery to client
+// deliver via Convex HTTP action SSE endpoint
 ```
 
-### 6. Convex Runtime Rules
+### 6 · Convex runtime boundaries
 ```typescript
-// "use node" files: ONLY actions and internalActions
-// Default runtime: queries + mutations + standard actions
+// "use node" files → only action / internalAction
+// default runtime  → queries + mutations
 
-// ✅ Correct internal call
+// ✅ internal call
 await ctx.runQuery(internal.apiKeys.getDecryptedForProvider, { provider })
-
-// ❌ Wrong — internal functions not accessible via api.*
+// ❌ wrong — internal functions not accessible via api.*
 await ctx.runQuery(api.apiKeys.getDecryptedForProvider, { provider })
 ```
 
-### 7. File Storage (No Fake Implementations)
+### 7 · File storage — no fake implementations
 ```typescript
-// ✅ Dev: Convex built-in storage
+// ✅ real storage
 const uploadUrl = await ctx.storage.generateUploadUrl()
-const storageId = await ctx.storage.store(file)
-
-// ✅ Prod: Mastra S3Filesystem → Cloudflare R2
-// ❌ Never: store file content as base64 in DB / metadata-only "upload"
+// ❌ never: url: 'pending-upload'
 ```
 
-### 8. Quality & Security After Every Sprint
-After every PR:
-1. Run full test suite: `pnpm test` — ALL must pass
-2. Security review: all mutations have server-side validation
-3. Live test: test feature against `watchful-chipmunk-946.convex.cloud`
-4. No `as any` on Convex mutation payloads
-5. No `window.confirm` / `alert` — use toast or two-step confirm pattern
+### 8 · dist/default ≡ templates/default
+Every change in `dist/default/` must be made identically in `templates/default/`.
+
+### 9 · QA + Security after every sprint
+- `pnpm test` — all green
+- all mutations have server-side input validation
+- live test on `watchful-chipmunk-946.convex.cloud`
+- document what was tested
 
 ---
 
-## 📋 Current Status (2026-02-27)
+## Current Status (2026-02-27)
 
-### ✅ Working
-- `agentforge agents list/create/edit/delete` — Convex connected
-- `agentforge chat <agent-id>` — API-level works (interactive TTY may have issues)
-- `agentforge cron list/create` — connected
-- `agentforge mcp list/add` — connected
-- `agentforge files list` — lists metadata
-- BYOK: `OpenAICompatibleConfig` — confirmed working end-to-end
+### ✅ Confirmed working (real Convex)
+- `executeAgent` → real LLM response
+- `chat.sendMessage` → real LLM response
+- `apiKeys.create` + BYOK chain
+- `agents.list`
 
-### 🐛 Broken (must fix before new features)
-- **AGE-170:** File upload is metadata-only — content never stored
-- **AGE-171:** Chat CLI interactive stdin broken
-- **AGE-172:** Skills dashboard uses `createTool` not SKILL.md
-- **AGE-173:** Streaming is placeholder — falls back to full generation
+### 🔨 Phase 0 PRs open (pending review)
+- PR #122: chat CLI interactive mode + --message flag (AGE-171)
+- PR #123: real Convex file storage (AGE-170)
+- PR #124: streaming SSE via Convex HTTP action (AGE-173)
+- PR #125: SKILL.md folder scaffolding (AGE-172)
 
-### 🔨 Missing Core Features
-- **AGE-174:** Dynamic model list from provider API
-- **AGE-175:** Mastra Workspace wired to agents
-- **AGE-159:** Streaming SSE via Convex HTTP actions
-- **AGE-157:** Complete project scoping (8 tables still unscoped)
-- **AGE-152:** File management in dashboard UI (upload button missing)
-
----
-
-## 🏗️ Sprint Execution Order
-
-### Phase 0 — Fix What's Broken (Start Here)
-1. AGE-170: Real file storage (Convex storage API)
-2. AGE-171: Chat CLI interactive mode
-3. AGE-173: Streaming (Convex HTTP + SSE)
-4. AGE-172: Skills → SKILL.md standard
-
-### Phase 1 — Core Completeness
-5. AGE-174: Dynamic model loading
-6. AGE-157: Complete project scoping
-7. AGE-152: File management UI
-8. AGE-175: Mastra Workspace integration
-
-### Phase 2 — Intelligence
-9. AGE-158: Context window management
-10. AGE-160: Model failover chains
-11. AGE-161: Browser automation (Playwright, native Mastra tool)
-12. AGE-143: Real MCP tool execution
-
-### Phase 3 — Platform
-13. AGE-162: Real-time dashboard (Convex reactive)
-14. AGE-145: Better Auth (multi-tenant)
-15. AGE-163: Usage metering + billing
-
----
-
-## 📦 Live Test Deployment
-
-```
-Deployment:  watchful-chipmunk-946.convex.cloud
-Project dir: /tmp/agentforge-test/agentforge-test
-Dashboard:   http://localhost:3000
-```
-
-**Every feature must be tested against this deployment before PR.**
-
----
-
-## ⚠️ CONVEX INIT IS MANDATORY — NO EXCEPTIONS
-
-You cannot test any feature without a running Convex deployment. Mocked unit tests do NOT count as verification.
-
-```bash
-# Required before any testing
-npx convex dev --once
-
-# Then test the feature for real:
-npx convex run agents:list
-agentforge chat <agent-id>
-# etc.
-```
-
-### Honesty Standard for "Working" Status
-A feature is only marked ✅ working if ALL of these are true:
-1. `npx convex dev --once` ran successfully
-2. The actual CLI command or Convex function was called against the live deployment
-3. A real (non-mock, non-empty) response was returned
-4. The command + output is documented
-
-### Confirmed Working (2026-02-27, real Convex)
-| Feature | Command | Result |
-|---------|---------|--------|
-| Agent execution | `npx convex run mastraIntegration:executeAgent` | Real OpenAI response ✅ |
-| Chat | `npx convex run chat:sendMessage` | Real OpenAI response ✅ |
-| API key storage | `npx convex run apiKeys:create` | Key stored + used ✅ |
-| Agents list | `agentforge agents list` | Real DB record ✅ |
-| File upload | `agentforge files upload` | BROKEN — metadata only ❌ |
-| Chat CLI interactive | `agentforge chat <id>` | BROKEN — exits immediately ❌ |
-
-### NOT Confirmed (Do Not Assume Working)
-- cron CRUD beyond `list`
+### ⚠️ Not yet confirmed end-to-end
+- cron CRUD beyond list
 - mcp add / connection test
 - skills install / create
-- agents create (interactive CLI), edit, delete, enable, disable
-- All dashboard pages in browser (code exists, never opened)
-- projects, sessions, threads end-to-end
+- agents create / edit / delete interactive paths
+- dashboard pages in browser
+
+---
+
+## Live Test Deployment
+
+```
+Deployment: watchful-chipmunk-946.convex.cloud
+Dir:        /tmp/agentforge-test/agentforge-test
+Run:        agentforge dashboard --dir /tmp/agentforge-test/agentforge-test
+```
+
+Convex must be initialized before testing: `npx convex dev --once`


### PR DESCRIPTION
Rewrites AGENTS.md and CLAUDE.md scope section to define what we ARE (framework CLI + local dashboard), not what we aren't. No external repo references. Auth/billing/hosting explicitly deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidance documentation to streamline workflow rules and ownership mappings.
  * Reorganized testing and deployment instructions for clarity.
  * Consolidated guidance on development practices and platform scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->