### PR TITLE
fix(dashboard): replace hardcoded settings state with real Convex data

### DIFF
--- a/packages/cli/dist/default/dashboard/app/routes/settings.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/settings.tsx
@@ -3,8 +3,9 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useEffect, useMemo, useState } from 'react';
 import { useAction, useMutation, useQuery } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { AlertTriangle, Check, ExternalLink, Key, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
+import { AlertTriangle, Check, ExternalLink, Key, Loader2, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
+import { deriveGeneralSettings, isSettingsLoaded } from '../lib/settings-helpers';
 
 export const Route = createFileRoute('/settings')({ component: SettingsPage });
 
@@ -22,7 +23,12 @@ const KEY_PREFIXES: Record<string, string> = {
 function SettingsPage() {
   const apiKeys = useQuery(api.apiKeys.list, {}) ?? [];
   const vaultSecrets = useQuery(api.vault.list, {}) ?? [];
-  const userSettings = useQuery(api.settings.list, { userId: LOCAL_SETTINGS_USER }) ?? [];
+  const userSettingsRaw = useQuery(api.settings.list, { userId: LOCAL_SETTINGS_USER });
+  const settingsLoaded = isSettingsLoaded(userSettingsRaw);
+  const savedGeneral = useMemo(
+    () => deriveGeneralSettings(userSettingsRaw ?? []),
+    [userSettingsRaw],
+  );
   const createApiKey = useAction(api.apiKeys.create);
   const removeApiKey = useMutation(api.apiKeys.remove);
   const toggleApiKey = useMutation(api.apiKeys.toggleActive);
@@ -39,10 +45,12 @@ function SettingsPage() {
   const [vaultForm, setVaultForm] = useState({ name: '', category: 'api_key', provider: '', value: '' });
   const [defaultModel, setDefaultModel] = useState('');
   const [defaultTemperature, setDefaultTemperature] = useState(0.7);
+  const [hasEditedGeneral, setHasEditedGeneral] = useState(false);
   const [confirmingDeleteKeyId, setConfirmingDeleteKeyId] = useState<string | null>(null);
   const [confirmingDeleteSecretId, setConfirmingDeleteSecretId] = useState<string | null>(null);
   const [savingGeneral, setSavingGeneral] = useState(false);
   const [generalSavedMessage, setGeneralSavedMessage] = useState<string | null>(null);
+  const [generalErrorMessage, setGeneralErrorMessage] = useState<string | null>(null);
 
   const keysByProvider = apiKeys.reduce((acc: Record<string, any[]>, key: any) => {
     if (!acc[key.provider]) acc[key.provider] = [];
@@ -65,16 +73,10 @@ function SettingsPage() {
   );
 
   useEffect(() => {
-    const savedDefaultModel = userSettings.find((setting: any) => setting.key === 'defaultModel')?.value;
-    const savedDefaultTemperature = userSettings.find((setting: any) => setting.key === 'defaultTemperature')?.value;
-
-    if (typeof savedDefaultModel === 'string') {
-      setDefaultModel(savedDefaultModel);
-    }
-    if (typeof savedDefaultTemperature === 'number') {
-      setDefaultTemperature(savedDefaultTemperature);
-    }
-  }, [userSettings]);
+    if (!settingsLoaded || hasEditedGeneral) return;
+    setDefaultModel(savedGeneral.defaultModel);
+    setDefaultTemperature(savedGeneral.defaultTemperature);
+  }, [settingsLoaded, savedGeneral, hasEditedGeneral]);
 
   const handleAddKey = async () => {
     if (!addingProvider || !newKeyValue.trim()) return;
@@ -110,6 +112,7 @@ function SettingsPage() {
 
   const handleSaveGeneral = async () => {
     setSavingGeneral(true);
+    setGeneralErrorMessage(null);
 
     try {
       if (defaultModel) {
@@ -131,8 +134,13 @@ function SettingsPage() {
         value: defaultTemperature,
       });
 
+      setHasEditedGeneral(false);
       setGeneralSavedMessage('General settings saved.');
       setTimeout(() => setGeneralSavedMessage(null), 3000);
+    } catch (error) {
+      setGeneralErrorMessage(
+        error instanceof Error ? error.message : 'Failed to save settings. Please try again.',
+      );
     } finally {
       setSavingGeneral(false);
     }
@@ -293,46 +301,54 @@ function SettingsPage() {
 
         {tab === 'general' && (
           <div className="space-y-6">
-            <div className="bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Workspace Configuration</h3>
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Default Model</label>
-                  <select
-                    value={defaultModel}
-                    onChange={(event) => setDefaultModel(event.target.value)}
-                    className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                  >
-                    <option value="">None (use agent default)</option>
-                    {allModels.map(({ provider, model }) => (
-                      <option key={`${provider}/${model}`} value={`${provider}/${model}`}>
-                        {model} ({provider})
-                      </option>
-                    ))}
-                    {catalogLoading && <option value="" disabled>Loading models…</option>}
-                  </select>
-                  <p className="text-xs text-muted-foreground mt-1">Used when creating new agents without specifying a model.</p>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1">Default Temperature</label>
-                  <input
-                    type="number"
-                    value={defaultTemperature}
-                    onChange={(event) => setDefaultTemperature(parseFloat(event.target.value) || 0)}
-                    step={0.1}
-                    min={0}
-                    max={2}
-                    className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-3 pt-2">
-                  <button onClick={handleSaveGeneral} disabled={savingGeneral} className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
-                    {savingGeneral ? 'Saving…' : 'Save General Settings'}
-                  </button>
-                  {generalSavedMessage && <span className="text-sm text-green-400">{generalSavedMessage}</span>}
+            {!settingsLoaded ? (
+              <div className="bg-card border border-border rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Loading settings…</span>
+              </div>
+            ) : (
+              <div className="bg-card border border-border rounded-lg p-6">
+                <h3 className="text-lg font-semibold mb-4">Workspace Configuration</h3>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Default Model</label>
+                    <select
+                      value={defaultModel}
+                      onChange={(event) => { setDefaultModel(event.target.value); setHasEditedGeneral(true); }}
+                      className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                    >
+                      <option value="">None (use agent default)</option>
+                      {allModels.map(({ provider, model }) => (
+                        <option key={`${provider}/${model}`} value={`${provider}/${model}`}>
+                          {model} ({provider})
+                        </option>
+                      ))}
+                      {catalogLoading && <option value="" disabled>Loading models…</option>}
+                    </select>
+                    <p className="text-xs text-muted-foreground mt-1">Used when creating new agents without specifying a model.</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Default Temperature</label>
+                    <input
+                      type="number"
+                      value={defaultTemperature}
+                      onChange={(event) => { setDefaultTemperature(parseFloat(event.target.value) || 0); setHasEditedGeneral(true); }}
+                      step={0.1}
+                      min={0}
+                      max={2}
+                      className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div className="flex items-center gap-3 pt-2">
+                    <button onClick={handleSaveGeneral} disabled={savingGeneral} className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+                      {savingGeneral ? 'Saving…' : 'Save General Settings'}
+                    </button>
+                    {generalSavedMessage && <span className="text-sm text-green-400">{generalSavedMessage}</span>}
+                    {generalErrorMessage && <span className="text-sm text-destructive">{generalErrorMessage}</span>}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         )}
 

--- a/packages/cli/templates/default/dashboard/app/lib/settings-helpers.ts
+++ b/packages/cli/templates/default/dashboard/app/lib/settings-helpers.ts
@@ -1,0 +1,38 @@
+export interface SettingsRecord {
+  key: string;
+  value: unknown;
+}
+
+export interface GeneralSettings {
+  defaultModel: string;
+  defaultTemperature: number;
+}
+
+const DEFAULTS: GeneralSettings = {
+  defaultModel: '',
+  defaultTemperature: 0.7,
+};
+
+export function isSettingsLoaded(
+  queryResult: SettingsRecord[] | undefined,
+): queryResult is SettingsRecord[] {
+  return queryResult !== undefined;
+}
+
+export function deriveGeneralSettings(
+  settings: SettingsRecord[],
+): GeneralSettings {
+  const modelEntry = settings.find((s) => s.key === 'defaultModel');
+  const tempEntry = settings.find((s) => s.key === 'defaultTemperature');
+
+  return {
+    defaultModel:
+      modelEntry && typeof modelEntry.value === 'string'
+        ? modelEntry.value
+        : DEFAULTS.defaultModel,
+    defaultTemperature:
+      tempEntry && typeof tempEntry.value === 'number'
+        ? tempEntry.value
+        : DEFAULTS.defaultTemperature,
+  };
+}

--- a/packages/cli/templates/default/dashboard/app/routes/settings.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/settings.tsx
@@ -3,8 +3,9 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useEffect, useMemo, useState } from 'react';
 import { useAction, useMutation, useQuery } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { AlertTriangle, Check, ExternalLink, Key, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
+import { AlertTriangle, Check, ExternalLink, Key, Loader2, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
+import { deriveGeneralSettings, isSettingsLoaded } from '../lib/settings-helpers';
 
 export const Route = createFileRoute('/settings')({ component: SettingsPage });
 
@@ -22,7 +23,12 @@ const KEY_PREFIXES: Record<string, string> = {
 function SettingsPage() {
   const apiKeys = useQuery(api.apiKeys.list, {}) ?? [];
   const vaultSecrets = useQuery(api.vault.list, {}) ?? [];
-  const userSettings = useQuery(api.settings.list, { userId: LOCAL_SETTINGS_USER }) ?? [];
+  const userSettingsRaw = useQuery(api.settings.list, { userId: LOCAL_SETTINGS_USER });
+  const settingsLoaded = isSettingsLoaded(userSettingsRaw);
+  const savedGeneral = useMemo(
+    () => deriveGeneralSettings(userSettingsRaw ?? []),
+    [userSettingsRaw],
+  );
   const createApiKey = useAction(api.apiKeys.create);
   const removeApiKey = useMutation(api.apiKeys.remove);
   const toggleApiKey = useMutation(api.apiKeys.toggleActive);
@@ -39,10 +45,12 @@ function SettingsPage() {
   const [vaultForm, setVaultForm] = useState({ name: '', category: 'api_key', provider: '', value: '' });
   const [defaultModel, setDefaultModel] = useState('');
   const [defaultTemperature, setDefaultTemperature] = useState(0.7);
+  const [hasEditedGeneral, setHasEditedGeneral] = useState(false);
   const [confirmingDeleteKeyId, setConfirmingDeleteKeyId] = useState<string | null>(null);
   const [confirmingDeleteSecretId, setConfirmingDeleteSecretId] = useState<string | null>(null);
   const [savingGeneral, setSavingGeneral] = useState(false);
   const [generalSavedMessage, setGeneralSavedMessage] = useState<string | null>(null);
+  const [generalErrorMessage, setGeneralErrorMessage] = useState<string | null>(null);
 
   const keysByProvider = apiKeys.reduce((acc: Record<string, any[]>, key: any) => {
     if (!acc[key.provider]) acc[key.provider] = [];
@@ -65,16 +73,10 @@ function SettingsPage() {
   );
 
   useEffect(() => {
-    const savedDefaultModel = userSettings.find((setting: any) => setting.key === 'defaultModel')?.value;
-    const savedDefaultTemperature = userSettings.find((setting: any) => setting.key === 'defaultTemperature')?.value;
-
-    if (typeof savedDefaultModel === 'string') {
-      setDefaultModel(savedDefaultModel);
-    }
-    if (typeof savedDefaultTemperature === 'number') {
-      setDefaultTemperature(savedDefaultTemperature);
-    }
-  }, [userSettings]);
+    if (!settingsLoaded || hasEditedGeneral) return;
+    setDefaultModel(savedGeneral.defaultModel);
+    setDefaultTemperature(savedGeneral.defaultTemperature);
+  }, [settingsLoaded, savedGeneral, hasEditedGeneral]);
 
   const handleAddKey = async () => {
     if (!addingProvider || !newKeyValue.trim()) return;
@@ -110,6 +112,7 @@ function SettingsPage() {
 
   const handleSaveGeneral = async () => {
     setSavingGeneral(true);
+    setGeneralErrorMessage(null);
 
     try {
       if (defaultModel) {
@@ -131,8 +134,13 @@ function SettingsPage() {
         value: defaultTemperature,
       });
 
+      setHasEditedGeneral(false);
       setGeneralSavedMessage('General settings saved.');
       setTimeout(() => setGeneralSavedMessage(null), 3000);
+    } catch (error) {
+      setGeneralErrorMessage(
+        error instanceof Error ? error.message : 'Failed to save settings. Please try again.',
+      );
     } finally {
       setSavingGeneral(false);
     }
@@ -293,46 +301,54 @@ function SettingsPage() {
 
         {tab === 'general' && (
           <div className="space-y-6">
-            <div className="bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Workspace Configuration</h3>
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Default Model</label>
-                  <select
-                    value={defaultModel}
-                    onChange={(event) => setDefaultModel(event.target.value)}
-                    className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                  >
-                    <option value="">None (use agent default)</option>
-                    {allModels.map(({ provider, model }) => (
-                      <option key={`${provider}/${model}`} value={`${provider}/${model}`}>
-                        {model} ({provider})
-                      </option>
-                    ))}
-                    {catalogLoading && <option value="" disabled>Loading models…</option>}
-                  </select>
-                  <p className="text-xs text-muted-foreground mt-1">Used when creating new agents without specifying a model.</p>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1">Default Temperature</label>
-                  <input
-                    type="number"
-                    value={defaultTemperature}
-                    onChange={(event) => setDefaultTemperature(parseFloat(event.target.value) || 0)}
-                    step={0.1}
-                    min={0}
-                    max={2}
-                    className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-3 pt-2">
-                  <button onClick={handleSaveGeneral} disabled={savingGeneral} className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
-                    {savingGeneral ? 'Saving…' : 'Save General Settings'}
-                  </button>
-                  {generalSavedMessage && <span className="text-sm text-green-400">{generalSavedMessage}</span>}
+            {!settingsLoaded ? (
+              <div className="bg-card border border-border rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Loading settings…</span>
+              </div>
+            ) : (
+              <div className="bg-card border border-border rounded-lg p-6">
+                <h3 className="text-lg font-semibold mb-4">Workspace Configuration</h3>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Default Model</label>
+                    <select
+                      value={defaultModel}
+                      onChange={(event) => { setDefaultModel(event.target.value); setHasEditedGeneral(true); }}
+                      className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                    >
+                      <option value="">None (use agent default)</option>
+                      {allModels.map(({ provider, model }) => (
+                        <option key={`${provider}/${model}`} value={`${provider}/${model}`}>
+                          {model} ({provider})
+                        </option>
+                      ))}
+                      {catalogLoading && <option value="" disabled>Loading models…</option>}
+                    </select>
+                    <p className="text-xs text-muted-foreground mt-1">Used when creating new agents without specifying a model.</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Default Temperature</label>
+                    <input
+                      type="number"
+                      value={defaultTemperature}
+                      onChange={(event) => { setDefaultTemperature(parseFloat(event.target.value) || 0); setHasEditedGeneral(true); }}
+                      step={0.1}
+                      min={0}
+                      max={2}
+                      className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div className="flex items-center gap-3 pt-2">
+                    <button onClick={handleSaveGeneral} disabled={savingGeneral} className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+                      {savingGeneral ? 'Saving…' : 'Save General Settings'}
+                    </button>
+                    {generalSavedMessage && <span className="text-sm text-green-400">{generalSavedMessage}</span>}
+                    {generalErrorMessage && <span className="text-sm text-destructive">{generalErrorMessage}</span>}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         )}
 

--- a/packages/web/app/lib/settings-helpers.test.ts
+++ b/packages/web/app/lib/settings-helpers.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveGeneralSettings,
+  isSettingsLoaded,
+  type SettingsRecord,
+} from './settings-helpers';
+
+describe('settings-helpers', () => {
+  describe('isSettingsLoaded', () => {
+    it('returns false when query result is undefined (loading)', () => {
+      expect(isSettingsLoaded(undefined)).toBe(false);
+    });
+
+    it('returns true when query result is an empty array (loaded, no settings)', () => {
+      expect(isSettingsLoaded([])).toBe(true);
+    });
+
+    it('returns true when query result has entries', () => {
+      const settings: SettingsRecord[] = [
+        { key: 'defaultModel', value: 'openai/gpt-4o' },
+      ];
+      expect(isSettingsLoaded(settings)).toBe(true);
+    });
+  });
+
+  describe('deriveGeneralSettings', () => {
+    it('returns defaults when settings array is empty', () => {
+      const result = deriveGeneralSettings([]);
+      expect(result).toEqual({
+        defaultModel: '',
+        defaultTemperature: 0.7,
+      });
+    });
+
+    it('extracts defaultModel from settings', () => {
+      const settings: SettingsRecord[] = [
+        { key: 'defaultModel', value: 'anthropic/claude-opus-4-6' },
+      ];
+      const result = deriveGeneralSettings(settings);
+      expect(result.defaultModel).toBe('anthropic/claude-opus-4-6');
+    });
+
+    it('extracts defaultTemperature from settings', () => {
+      const settings: SettingsRecord[] = [
+        { key: 'defaultTemperature', value: 0.3 },
+      ];
+      const result = deriveGeneralSettings(settings);
+      expect(result.defaultTemperature).toBe(0.3);
+    });
+
+    it('extracts both settings when present', () => {
+      const settings: SettingsRecord[] = [
+        { key: 'defaultModel', value: 'openai/gpt-4o' },
+        { key: 'defaultTemperature', value: 1.2 },
+      ];
+      const result = deriveGeneralSettings(settings);
+      expect(result).toEqual({
+        defaultModel: 'openai/gpt-4o',
+        defaultTemperature: 1.2,
+      });
+    });
+
+    it('ignores non-string defaultModel values', () => {
+      const settings: SettingsRecord[] = [
+        { key: 'defaultModel', value: 42 },
+      ];
+      const result = deriveGeneralSettings(settings);
+      expect(result.defaultModel).toBe('');
+    });
+
+    it('ignores non-number defaultTemperature values', () => {
+      const settings: SettingsRecord[] = [
+        { key: 'defaultTemperature', value: 'high' },
+      ];
+      const result = deriveGeneralSettings(settings);
+      expect(result.defaultTemperature).toBe(0.7);
+    });
+
+    it('ignores unknown keys', () => {
+      const settings: SettingsRecord[] = [
+        { key: 'unknownSetting', value: 'something' },
+      ];
+      const result = deriveGeneralSettings(settings);
+      expect(result).toEqual({
+        defaultModel: '',
+        defaultTemperature: 0.7,
+      });
+    });
+  });
+});

--- a/packages/web/app/lib/settings-helpers.ts
+++ b/packages/web/app/lib/settings-helpers.ts
@@ -1,0 +1,38 @@
+export interface SettingsRecord {
+  key: string;
+  value: unknown;
+}
+
+export interface GeneralSettings {
+  defaultModel: string;
+  defaultTemperature: number;
+}
+
+const DEFAULTS: GeneralSettings = {
+  defaultModel: '',
+  defaultTemperature: 0.7,
+};
+
+export function isSettingsLoaded(
+  queryResult: SettingsRecord[] | undefined,
+): queryResult is SettingsRecord[] {
+  return queryResult !== undefined;
+}
+
+export function deriveGeneralSettings(
+  settings: SettingsRecord[],
+): GeneralSettings {
+  const modelEntry = settings.find((s) => s.key === 'defaultModel');
+  const tempEntry = settings.find((s) => s.key === 'defaultTemperature');
+
+  return {
+    defaultModel:
+      modelEntry && typeof modelEntry.value === 'string'
+        ? modelEntry.value
+        : DEFAULTS.defaultModel,
+    defaultTemperature:
+      tempEntry && typeof tempEntry.value === 'number'
+        ? tempEntry.value
+        : DEFAULTS.defaultTemperature,
+  };
+}

--- a/packages/web/app/routes/settings.tsx
+++ b/packages/web/app/routes/settings.tsx
@@ -3,8 +3,9 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useEffect, useMemo, useState } from 'react';
 import { useAction, useMutation, useQuery } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { AlertTriangle, Check, ExternalLink, Key, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
+import { AlertTriangle, Check, ExternalLink, Key, Loader2, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
+import { deriveGeneralSettings, isSettingsLoaded } from '../lib/settings-helpers';
 
 export const Route = createFileRoute('/settings')({ component: SettingsPage });
 
@@ -22,7 +23,12 @@ const KEY_PREFIXES: Record<string, string> = {
 function SettingsPage() {
   const apiKeys = useQuery(api.apiKeys.list, {}) ?? [];
   const vaultSecrets = useQuery(api.vault.list, {}) ?? [];
-  const userSettings = useQuery(api.settings.list, { userId: LOCAL_SETTINGS_USER }) ?? [];
+  const userSettingsRaw = useQuery(api.settings.list, { userId: LOCAL_SETTINGS_USER });
+  const settingsLoaded = isSettingsLoaded(userSettingsRaw);
+  const savedGeneral = useMemo(
+    () => deriveGeneralSettings(userSettingsRaw ?? []),
+    [userSettingsRaw],
+  );
   const createApiKey = useAction(api.apiKeys.create);
   const removeApiKey = useMutation(api.apiKeys.remove);
   const toggleApiKey = useMutation(api.apiKeys.toggleActive);
@@ -39,10 +45,12 @@ function SettingsPage() {
   const [vaultForm, setVaultForm] = useState({ name: '', category: 'api_key', provider: '', value: '' });
   const [defaultModel, setDefaultModel] = useState('');
   const [defaultTemperature, setDefaultTemperature] = useState(0.7);
+  const [hasEditedGeneral, setHasEditedGeneral] = useState(false);
   const [confirmingDeleteKeyId, setConfirmingDeleteKeyId] = useState<string | null>(null);
   const [confirmingDeleteSecretId, setConfirmingDeleteSecretId] = useState<string | null>(null);
   const [savingGeneral, setSavingGeneral] = useState(false);
   const [generalSavedMessage, setGeneralSavedMessage] = useState<string | null>(null);
+  const [generalErrorMessage, setGeneralErrorMessage] = useState<string | null>(null);
 
   const keysByProvider = apiKeys.reduce((acc: Record<string, any[]>, key: any) => {
     if (!acc[key.provider]) acc[key.provider] = [];
@@ -65,16 +73,10 @@ function SettingsPage() {
   );
 
   useEffect(() => {
-    const savedDefaultModel = userSettings.find((setting: any) => setting.key === 'defaultModel')?.value;
-    const savedDefaultTemperature = userSettings.find((setting: any) => setting.key === 'defaultTemperature')?.value;
-
-    if (typeof savedDefaultModel === 'string') {
-      setDefaultModel(savedDefaultModel);
-    }
-    if (typeof savedDefaultTemperature === 'number') {
-      setDefaultTemperature(savedDefaultTemperature);
-    }
-  }, [userSettings]);
+    if (!settingsLoaded || hasEditedGeneral) return;
+    setDefaultModel(savedGeneral.defaultModel);
+    setDefaultTemperature(savedGeneral.defaultTemperature);
+  }, [settingsLoaded, savedGeneral, hasEditedGeneral]);
 
   const handleAddKey = async () => {
     if (!addingProvider || !newKeyValue.trim()) return;
@@ -110,6 +112,7 @@ function SettingsPage() {
 
   const handleSaveGeneral = async () => {
     setSavingGeneral(true);
+    setGeneralErrorMessage(null);
 
     try {
       if (defaultModel) {
@@ -131,8 +134,13 @@ function SettingsPage() {
         value: defaultTemperature,
       });
 
+      setHasEditedGeneral(false);
       setGeneralSavedMessage('General settings saved.');
       setTimeout(() => setGeneralSavedMessage(null), 3000);
+    } catch (error) {
+      setGeneralErrorMessage(
+        error instanceof Error ? error.message : 'Failed to save settings. Please try again.',
+      );
     } finally {
       setSavingGeneral(false);
     }
@@ -293,46 +301,54 @@ function SettingsPage() {
 
         {tab === 'general' && (
           <div className="space-y-6">
-            <div className="bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Workspace Configuration</h3>
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Default Model</label>
-                  <select
-                    value={defaultModel}
-                    onChange={(event) => setDefaultModel(event.target.value)}
-                    className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                  >
-                    <option value="">None (use agent default)</option>
-                    {allModels.map(({ provider, model }) => (
-                      <option key={`${provider}/${model}`} value={`${provider}/${model}`}>
-                        {model} ({provider})
-                      </option>
-                    ))}
-                    {catalogLoading && <option value="" disabled>Loading models…</option>}
-                  </select>
-                  <p className="text-xs text-muted-foreground mt-1">Used when creating new agents without specifying a model.</p>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1">Default Temperature</label>
-                  <input
-                    type="number"
-                    value={defaultTemperature}
-                    onChange={(event) => setDefaultTemperature(parseFloat(event.target.value) || 0)}
-                    step={0.1}
-                    min={0}
-                    max={2}
-                    className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-3 pt-2">
-                  <button onClick={handleSaveGeneral} disabled={savingGeneral} className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
-                    {savingGeneral ? 'Saving…' : 'Save General Settings'}
-                  </button>
-                  {generalSavedMessage && <span className="text-sm text-green-400">{generalSavedMessage}</span>}
+            {!settingsLoaded ? (
+              <div className="bg-card border border-border rounded-lg p-6 flex items-center justify-center gap-2 text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Loading settings…</span>
+              </div>
+            ) : (
+              <div className="bg-card border border-border rounded-lg p-6">
+                <h3 className="text-lg font-semibold mb-4">Workspace Configuration</h3>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Default Model</label>
+                    <select
+                      value={defaultModel}
+                      onChange={(event) => { setDefaultModel(event.target.value); setHasEditedGeneral(true); }}
+                      className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                    >
+                      <option value="">None (use agent default)</option>
+                      {allModels.map(({ provider, model }) => (
+                        <option key={`${provider}/${model}`} value={`${provider}/${model}`}>
+                          {model} ({provider})
+                        </option>
+                      ))}
+                      {catalogLoading && <option value="" disabled>Loading models…</option>}
+                    </select>
+                    <p className="text-xs text-muted-foreground mt-1">Used when creating new agents without specifying a model.</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Default Temperature</label>
+                    <input
+                      type="number"
+                      value={defaultTemperature}
+                      onChange={(event) => { setDefaultTemperature(parseFloat(event.target.value) || 0); setHasEditedGeneral(true); }}
+                      step={0.1}
+                      min={0}
+                      max={2}
+                      className="w-full max-w-sm bg-background border border-border rounded-md px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div className="flex items-center gap-3 pt-2">
+                    <button onClick={handleSaveGeneral} disabled={savingGeneral} className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+                      {savingGeneral ? 'Saving…' : 'Save General Settings'}
+                    </button>
+                    {generalSavedMessage && <span className="text-sm text-green-400">{generalSavedMessage}</span>}
+                    {generalErrorMessage && <span className="text-sm text-destructive">{generalErrorMessage}</span>}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         )}
 

--- a/specs/active/SPEC-218-settings-real-data.md
+++ b/specs/active/SPEC-218-settings-real-data.md
@@ -1,0 +1,51 @@
+# [SPEC-218] Settings page — replace hardcoded state with real Convex data
+
+**Status:** Active | **Priority:** P1 | **Assigned:** frontend-engineer
+**Created:** 2026-03-12 | **Updated:** 2026-03-12
+**GitHub Issue:** #218
+
+## Overview
+The settings page uses `useState` with hardcoded defaults for general settings (defaultModel, defaultTemperature). While Convex queries/mutations are wired up, the state management has bugs: initial defaults flash before real data loads, save errors are swallowed, and there is no loading indicator.
+
+## Problem Statement
+Settings defaults in `useState('')` and `useState(0.7)` render immediately before the Convex `useQuery` returns. On first load or refresh this produces a visible flash of incorrect state. Save errors are silently swallowed with no user feedback. There is no distinction between "loading" and "no saved value".
+
+## Goals
+- General settings derive their displayed values from Convex query results, not hardcoded useState defaults
+- Save operations show error feedback on failure
+- Loading state is visible while settings are being fetched
+- The page works correctly on first load with no saved settings (empty initial state)
+- Settings persist correctly across refresh
+
+## Non-Goals
+- Redesigning the settings page layout
+- Enterprise auth or org settings
+- Hand-rolled modal fix (covered by Issue #219)
+
+## Proposed Solution
+
+### 1. Replace useState defaults with derived state from Convex
+Instead of `useState('')` + `useEffect` sync, derive `defaultModel` and `defaultTemperature` directly from the `userSettings` query result. Use local state only as an edit buffer initialized from the query.
+
+### 2. Add loading state
+Show a loading skeleton or disabled state while `userSettings` query result is `undefined` (Convex initial load).
+
+### 3. Add error handling on save
+Wrap `handleSaveGeneral` in try/catch with a visible error message.
+
+## Implementation Plan
+1. Track whether userSettings query has loaded (undefined vs [])
+2. Initialize edit buffer from query results, not hardcoded defaults
+3. Add error state + UI for save failures
+4. Add loading indicator for general tab
+5. Sync changes across all 4 template locations
+
+## Testing Plan
+- Unit test: settings page renders loading state when query is undefined
+- Unit test: settings page renders saved values when query returns data
+- Unit test: save button calls Convex mutation with correct args
+- Unit test: save error shows error message
+- Unit test: empty initial state shows correct defaults
+
+## Files Changed
+- `packages/web/app/routes/settings.tsx` (and synced to 3 other locations)


### PR DESCRIPTION
## Summary
- Extracts settings derivation logic into `settings-helpers.ts` with full unit tests
- Fixes flash-of-incorrect-state by distinguishing Convex loading (`undefined`) from empty state (`[]`)
- Shows a loading spinner on the General tab while Convex settings query loads
- Adds error feedback on save failure (previously silently swallowed)
- Tracks edit state so real-time Convex updates don't clobber in-progress user edits
- Synced across all template locations per Rule 6

## Test plan
- [x] 10 unit tests for `deriveGeneralSettings` and `isSettingsLoaded` (all pass)
- [ ] Manual: open Settings > General tab -- should show loading spinner, then real data
- [ ] Manual: change temperature, save -- confirm persists across refresh
- [ ] Manual: save with daemon stopped -- confirm error message shown

Closes #218

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings page now displays a loading indicator while fetching settings data.
  * Enhanced error handling with visible messaging when saving general settings fails.

* **Tests**
  * Added unit tests for settings initialization and validation logic.

* **Documentation**
  * Added specification documenting the settings data-driven defaults implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->