### PR TITLE
fix(security): revert censorMessage to mutation, make detectSecrets internal

### DIFF
--- a/convex/vault.ts
+++ b/convex/vault.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query, internalMutation, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
 
 // Crypto operations (encrypt/decrypt secrets) are in vaultCrypto.ts ("use node").
 // This file contains only V8-safe queries and mutations — no crypto.subtle.
@@ -288,7 +289,7 @@ export const remove = mutation({
 
 // ---- Secret Detection Utility ----
 
-export const detectSecrets = query({
+export const detectSecrets = internalQuery({
   args: { text: v.string() },
   handler: async (_ctx, args) => {
     const detected: Array<{
@@ -319,15 +320,17 @@ export const detectSecrets = query({
   },
 });
 
-// censorMessage is kept as a query-only detection utility.
-// The encryption part must be handled via vaultCrypto.encryptAndStore.
-export const censorMessage = query({
+// Censor a message by replacing detected secrets with masked versions
+// and scheduling encrypted storage in the vault via vaultCrypto.
+export const censorMessage = mutation({
   args: {
     text: v.string(),
+    userId: v.optional(v.string()),
+    autoStore: v.optional(v.boolean()),
   },
-  handler: async (_ctx, args) => {
+  handler: async (ctx, args) => {
     let censoredText = args.text;
-    const detectedSecrets: Array<{ name: string; masked: string; category: string; provider: string }> = [];
+    const storedSecrets: Array<{ name: string; masked: string }> = [];
 
     for (const { pattern, category, provider, name } of SECRET_PATTERNS) {
       const regex = new RegExp(pattern, "g");
@@ -335,15 +338,29 @@ export const censorMessage = query({
       while ((match = regex.exec(args.text)) !== null) {
         const secretValue = match[0];
         const masked = maskSecret(secretValue);
+
         censoredText = censoredText.replace(secretValue, `[REDACTED: ${masked}]`);
-        detectedSecrets.push({ name, masked, category, provider });
+
+        if (args.autoStore !== false) {
+          // Delegate encryption to Node.js action (fire-and-forget)
+          await ctx.scheduler.runAfter(0, internal.vaultCrypto.encryptAndStore, {
+            name: `${name} (auto-captured)`,
+            category,
+            provider,
+            value: secretValue,
+            userId: args.userId,
+            source: "chat",
+          });
+
+          storedSecrets.push({ name, masked });
+        }
       }
     }
 
     return {
       censoredText,
-      secretsDetected: detectedSecrets.length > 0,
-      detectedSecrets,
+      secretsDetected: storedSecrets.length > 0,
+      storedSecrets,
       originalHadSecrets: censoredText !== args.text,
     };
   },

--- a/packages/cli/templates/default/convex/vault.ts
+++ b/packages/cli/templates/default/convex/vault.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query, internalMutation, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
 
 // Crypto operations (encrypt/decrypt secrets) are in vaultCrypto.ts ("use node").
 // This file contains only V8-safe queries and mutations — no crypto.subtle.
@@ -288,7 +289,7 @@ export const remove = mutation({
 
 // ---- Secret Detection Utility ----
 
-export const detectSecrets = query({
+export const detectSecrets = internalQuery({
   args: { text: v.string() },
   handler: async (_ctx, args) => {
     const detected: Array<{
@@ -319,15 +320,17 @@ export const detectSecrets = query({
   },
 });
 
-// censorMessage is kept as a query-only detection utility.
-// The encryption part must be handled via vaultCrypto.encryptAndStore.
-export const censorMessage = query({
+// Censor a message by replacing detected secrets with masked versions
+// and scheduling encrypted storage in the vault via vaultCrypto.
+export const censorMessage = mutation({
   args: {
     text: v.string(),
+    userId: v.optional(v.string()),
+    autoStore: v.optional(v.boolean()),
   },
-  handler: async (_ctx, args) => {
+  handler: async (ctx, args) => {
     let censoredText = args.text;
-    const detectedSecrets: Array<{ name: string; masked: string; category: string; provider: string }> = [];
+    const storedSecrets: Array<{ name: string; masked: string }> = [];
 
     for (const { pattern, category, provider, name } of SECRET_PATTERNS) {
       const regex = new RegExp(pattern, "g");
@@ -335,15 +338,29 @@ export const censorMessage = query({
       while ((match = regex.exec(args.text)) !== null) {
         const secretValue = match[0];
         const masked = maskSecret(secretValue);
+
         censoredText = censoredText.replace(secretValue, `[REDACTED: ${masked}]`);
-        detectedSecrets.push({ name, masked, category, provider });
+
+        if (args.autoStore !== false) {
+          // Delegate encryption to Node.js action (fire-and-forget)
+          await ctx.scheduler.runAfter(0, internal.vaultCrypto.encryptAndStore, {
+            name: `${name} (auto-captured)`,
+            category,
+            provider,
+            value: secretValue,
+            userId: args.userId,
+            source: "chat",
+          });
+
+          storedSecrets.push({ name, masked });
+        }
       }
     }
 
     return {
       censoredText,
-      secretsDetected: detectedSecrets.length > 0,
-      detectedSecrets,
+      secretsDetected: storedSecrets.length > 0,
+      storedSecrets,
       originalHadSecrets: censoredText !== args.text,
     };
   },

--- a/templates/default/convex/vault.ts
+++ b/templates/default/convex/vault.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query, internalMutation, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
 
 // Crypto operations (encrypt/decrypt secrets) are in vaultCrypto.ts ("use node").
 // This file contains only V8-safe queries and mutations — no crypto.subtle.
@@ -288,7 +289,7 @@ export const remove = mutation({
 
 // ---- Secret Detection Utility ----
 
-export const detectSecrets = query({
+export const detectSecrets = internalQuery({
   args: { text: v.string() },
   handler: async (_ctx, args) => {
     const detected: Array<{
@@ -319,15 +320,17 @@ export const detectSecrets = query({
   },
 });
 
-// censorMessage is kept as a query-only detection utility.
-// The encryption part must be handled via vaultCrypto.encryptAndStore.
-export const censorMessage = query({
+// Censor a message by replacing detected secrets with masked versions
+// and scheduling encrypted storage in the vault via vaultCrypto.
+export const censorMessage = mutation({
   args: {
     text: v.string(),
+    userId: v.optional(v.string()),
+    autoStore: v.optional(v.boolean()),
   },
-  handler: async (_ctx, args) => {
+  handler: async (ctx, args) => {
     let censoredText = args.text;
-    const detectedSecrets: Array<{ name: string; masked: string; category: string; provider: string }> = [];
+    const storedSecrets: Array<{ name: string; masked: string }> = [];
 
     for (const { pattern, category, provider, name } of SECRET_PATTERNS) {
       const regex = new RegExp(pattern, "g");
@@ -335,15 +338,29 @@ export const censorMessage = query({
       while ((match = regex.exec(args.text)) !== null) {
         const secretValue = match[0];
         const masked = maskSecret(secretValue);
+
         censoredText = censoredText.replace(secretValue, `[REDACTED: ${masked}]`);
-        detectedSecrets.push({ name, masked, category, provider });
+
+        if (args.autoStore !== false) {
+          // Delegate encryption to Node.js action (fire-and-forget)
+          await ctx.scheduler.runAfter(0, internal.vaultCrypto.encryptAndStore, {
+            name: `${name} (auto-captured)`,
+            category,
+            provider,
+            value: secretValue,
+            userId: args.userId,
+            source: "chat",
+          });
+
+          storedSecrets.push({ name, masked });
+        }
       }
     }
 
     return {
       censoredText,
-      secretsDetected: detectedSecrets.length > 0,
-      detectedSecrets,
+      secretsDetected: storedSecrets.length > 0,
+      storedSecrets,
       originalHadSecrets: censoredText !== args.text,
     };
   },


### PR DESCRIPTION
## Summary
- **Revert `censorMessage` from `query` back to `mutation`** — PR #237 changed it to a query, but `chat.tsx:93` calls `useMutation(api.vault.censorMessage)` with `userId`/`autoStore` args and reads `storedSecrets` from the response. This would crash at runtime.
- **Restore vault auto-storage** — detected secrets are now encrypted and stored via `ctx.scheduler.runAfter(0, internal.vaultCrypto.encryptAndStore, ...)`, keeping crypto in the Node.js runtime per architecture rules.
- **Change `detectSecrets` from public `query` to `internalQuery`** — this function returns `match: match[0]` (full plaintext secret values) and is not called from any client code. Making it internal prevents public enumeration of detected secrets.

All 3 tracked `vault.ts` locations updated (Rule 6).

## Test plan
- [ ] Verify `pnpm test` passes (dashboard-regressions.test.ts expects `useMutation(api.vault.censorMessage)`)
- [ ] Verify `tsc --noEmit` passes
- [ ] Manual test: send a message containing an API key pattern in chat — confirm it gets redacted and stored in vault
- [ ] Verify `api.vault.detectSecrets` is no longer accessible from client

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-storage capability for detected secrets when censoring messages.
  * Added support for associating secrets with user IDs during storage.

* **Chores**
  * Updated secret management response structure to include stored secrets metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->