### PR TITLE
fix(dashboard): modal outside-click dismissal (#219)

### DIFF
--- a/packages/cli/dist/default/dashboard/app/routes/agents.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/agents.tsx
@@ -3,7 +3,8 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useState, useMemo, useEffect } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { Bot, Plus, Edit, Trash2, Search, X, Loader2 } from 'lucide-react';
+import { Bot, Plus, Edit, Trash2, Search, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
 
 export const Route = createFileRoute('/agents')({ component: AgentsPage });
@@ -147,24 +148,26 @@ function AgentsPage() {
           </div>
         )}
 
-        {isModalOpen && (
-          <AgentModal
-            key={editingAgent?._id ?? 'create'}
-            agent={editingAgent}
-            modelsByProvider={modelsByProvider}
-            modelsLoading={catalogLoading}
-            onClose={() => { setIsModalOpen(false); setEditingAgent(null); }}
-            onSave={handleSave}
-            providerIds={providerIds}
-            providersById={providersById}
-          />
-        )}
+        <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) { setIsModalOpen(false); setEditingAgent(null); } }}>
+          <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col">
+            <AgentModalContent
+              key={editingAgent?._id ?? 'create'}
+              agent={editingAgent}
+              modelsByProvider={modelsByProvider}
+              modelsLoading={catalogLoading}
+              onClose={() => { setIsModalOpen(false); setEditingAgent(null); }}
+              onSave={handleSave}
+              providerIds={providerIds}
+              providersById={providersById}
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
 }
 
-function AgentModal({
+function AgentModalContent({
   agent,
   onSave,
   onClose,
@@ -257,13 +260,11 @@ function AgentModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex justify-center items-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <h2 className="text-lg font-bold">{agent ? 'Edit Agent' : 'Create Agent'}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-        </div>
-        <form onSubmit={handleSubmit} className="flex-grow overflow-y-auto p-6 space-y-4">
+    <>
+      <DialogHeader>
+        <DialogTitle>{agent ? 'Edit Agent' : 'Create Agent'}</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="flex-grow overflow-y-auto space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Name {formData.name.length}/{VALIDATION.name.maxLength}</label>
             <input
@@ -361,11 +362,10 @@ function AgentModal({
             </div>
           </div>
         </form>
-        <div className="flex justify-end p-4 border-t border-border gap-2">
-          <button type="button" onClick={onClose} className="bg-background border border-border px-4 py-2 rounded-lg hover:bg-muted">Cancel</button>
-          <button type="submit" onClick={handleSubmit} disabled={!formData.name.trim()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed">Save Agent</button>
-        </div>
-      </div>
-    </div>
+      <DialogFooter>
+        <button type="button" onClick={onClose} className="bg-background border border-border px-4 py-2 rounded-lg hover:bg-muted">Cancel</button>
+        <button type="submit" onClick={handleSubmit} disabled={!formData.name.trim()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed">Save Agent</button>
+      </DialogFooter>
+    </>
   );
 }

--- a/packages/cli/dist/default/dashboard/app/routes/connections.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/connections.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useAction } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Plug, Plus, Trash2, Search, X, Check, ExternalLink, Globe, Database, Mail, MessageSquare, FileText, Code, Zap, Shield, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/connections')({ component: ConnectionsPage });
 
@@ -292,44 +293,45 @@ function ConnectionsPage() {
         )}
 
         {/* Connect Modal */}
-        {connectingItem && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Connect {connectingItem.name}</h2>
-                <button onClick={() => setConnectingItem(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <div className="p-6 space-y-4">
-                <p className="text-sm text-muted-foreground">{connectingItem.description}</p>
-                {connectingItem.authFields.length > 0 ? (
-                  <div className="space-y-3">
-                    <h3 className="text-sm font-semibold">Authentication</h3>
-                    {connectingItem.authFields.map(field => (
-                      <div key={field.key}>
-                        <div className="flex items-center justify-between mb-1">
-                          <label className="text-sm font-medium">{field.label}</label>
-                          {field.helpUrl && <a href={field.helpUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Get token <ExternalLink className="w-3 h-3" /></a>}
+        <Dialog open={!!connectingItem} onOpenChange={(open) => { if (!open) setConnectingItem(null); }}>
+          <DialogContent className="max-w-lg">
+            {connectingItem && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Connect {connectingItem.name}</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <p className="text-sm text-muted-foreground">{connectingItem.description}</p>
+                  {connectingItem.authFields.length > 0 ? (
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-semibold">Authentication</h3>
+                      {connectingItem.authFields.map(field => (
+                        <div key={field.key}>
+                          <div className="flex items-center justify-between mb-1">
+                            <label className="text-sm font-medium">{field.label}</label>
+                            {field.helpUrl && <a href={field.helpUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Get token <ExternalLink className="w-3 h-3" /></a>}
+                          </div>
+                          <input type="password" placeholder={field.placeholder} value={authValues[field.key] || ''} onChange={(e) => setAuthValues(prev => ({ ...prev, [field.key]: e.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary font-mono" />
                         </div>
-                        <input type="password" placeholder={field.placeholder} value={authValues[field.key] || ''} onChange={(e) => setAuthValues(prev => ({ ...prev, [field.key]: e.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary font-mono" />
-                      </div>
-                    ))}
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-green-500">No authentication required for this integration.</p>
+                  )}
+                  <div className="bg-muted/50 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground font-mono">{connectingItem.serverUrl}</p>
                   </div>
-                ) : (
-                  <p className="text-sm text-green-500">No authentication required for this integration.</p>
-                )}
-                <div className="bg-muted/50 rounded-lg p-3">
-                  <p className="text-xs text-muted-foreground font-mono">{connectingItem.serverUrl}</p>
                 </div>
-              </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setConnectingItem(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleConnect} disabled={connectingItem.authFields.length > 0 && connectingItem.authFields.some(f => !authValues[f.key])} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
-                  <Plug className="w-4 h-4" /> Connect
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+                <DialogFooter>
+                  <button onClick={() => setConnectingItem(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+                  <button onClick={handleConnect} disabled={connectingItem.authFields.length > 0 && connectingItem.authFields.some(f => !authValues[f.key])} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
+                    <Plug className="w-4 h-4" /> Connect
+                  </button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/cli/dist/default/dashboard/app/routes/cron.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/cron.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Clock, Play, Pause, Plus, History, Trash2, Edit, X, AlertCircle, CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/cron')({ component: CronPage });
 
@@ -185,12 +186,16 @@ function CronPage() {
           </div>
         )}
 
-        {isCreateModalOpen && (
-          <CronModal agents={agents} onSave={handleCreate} onClose={() => setIsCreateModalOpen(false)} />
-        )}
-        {editingJob && (
-          <CronModal agents={agents} job={editingJob} onSave={handleEdit} onClose={() => setEditingJob(null)} />
-        )}
+        <Dialog open={isCreateModalOpen} onOpenChange={(open) => { if (!open) setIsCreateModalOpen(false); }}>
+          <DialogContent className="max-w-lg">
+            <CronModalContent agents={agents} onSave={handleCreate} onClose={() => setIsCreateModalOpen(false)} />
+          </DialogContent>
+        </Dialog>
+        <Dialog open={!!editingJob} onOpenChange={(open) => { if (!open) setEditingJob(null); }}>
+          <DialogContent className="max-w-lg">
+            {editingJob && <CronModalContent agents={agents} job={editingJob} onSave={handleEdit} onClose={() => setEditingJob(null)} />}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
@@ -240,7 +245,7 @@ function RunHistoryPanel({ cronJobId, onClose }: { cronJobId: any; onClose: () =
   );
 }
 
-function CronModal({
+function CronModalContent({
   agents,
   job,
   onSave,
@@ -283,15 +288,11 @@ function CronModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <h2 className="text-lg font-bold">{job ? 'Edit Scheduled Task' : 'New Scheduled Task'}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+    <>
+      <DialogHeader>
+        <DialogTitle>{job ? 'Edit Scheduled Task' : 'New Scheduled Task'}</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Name</label>
             <input
@@ -370,19 +371,18 @@ function CronModal({
             />
           </div>
         </form>
-        <div className="p-4 border-t border-border flex justify-end gap-2">
-          <button onClick={onClose} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">
-            Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!form.name || !form.agentId || !form.prompt}
-            className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
-          >
-            {job ? 'Update Schedule' : 'Create Schedule'}
-          </button>
-        </div>
-      </div>
-    </div>
+      <DialogFooter>
+        <button onClick={onClose} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">
+          Cancel
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={!form.name || !form.agentId || !form.prompt}
+          className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
+        >
+          {job ? 'Update Schedule' : 'Create Schedule'}
+        </button>
+      </DialogFooter>
+    </>
   );
 }

--- a/packages/cli/dist/default/dashboard/app/routes/projects.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/projects.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Id } from '@convex/_generated/dataModel';
 import { FolderKanban, Plus, Trash2, Edit, Search, X, Bot, Settings, Check } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog } from '../lib/model-catalog';
 
 export const Route = createFileRoute('/projects')({ component: ProjectsPage });
@@ -163,28 +164,29 @@ function ProjectsPage() {
           </div>
         )}
 
-        {isModalOpen && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">{editingProject ? 'Edit Project' : 'New Project'}</h2>
-                <button onClick={() => { setIsModalOpen(false); setEditingProject(null); }} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <ProjectForm key={editingProject?._id ?? 'create'} initial={editingProject} onSave={handleSave} onClose={() => { setIsModalOpen(false); setEditingProject(null); }} />
-            </div>
-          </div>
-        )}
+        <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) { setIsModalOpen(false); setEditingProject(null); } }}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>{editingProject ? 'Edit Project' : 'New Project'}</DialogTitle>
+            </DialogHeader>
+            <ProjectForm key={editingProject?._id ?? 'create'} initial={editingProject} onSave={handleSave} onClose={() => { setIsModalOpen(false); setEditingProject(null); }} />
+          </DialogContent>
+        </Dialog>
 
-        {isDetailOpen && detailProject && (
-          <ProjectDetailModal
-            project={detailProject}
-            allAgents={allAgents}
-            onClose={() => { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); }}
-            onToggleAgent={handleToggleAgent}
-            onSettingsSave={handleSettingsSave}
-            confirmingUnassignAgentId={confirmingUnassignAgentId}
-          />
-        )}
+        <Dialog open={isDetailOpen && !!detailProject} onOpenChange={(open) => { if (!open) { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); } }}>
+          <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col">
+            {detailProject && (
+              <ProjectDetailContent
+                project={detailProject}
+                allAgents={allAgents}
+                onClose={() => { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); }}
+                onToggleAgent={handleToggleAgent}
+                onSettingsSave={handleSettingsSave}
+                confirmingUnassignAgentId={confirmingUnassignAgentId}
+              />
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
@@ -219,7 +221,7 @@ function ProjectForm({ initial, onSave, onClose }: { initial: any; onSave: (data
   );
 }
 
-interface ProjectDetailModalProps {
+interface ProjectDetailContentProps {
   project: any;
   allAgents: any[];
   onClose: () => void;
@@ -228,7 +230,7 @@ interface ProjectDetailModalProps {
   confirmingUnassignAgentId: string | null;
 }
 
-function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSettingsSave, confirmingUnassignAgentId }: ProjectDetailModalProps) {
+function ProjectDetailContent({ project, allAgents, onClose, onToggleAgent, onSettingsSave, confirmingUnassignAgentId }: ProjectDetailContentProps) {
   const [activeTab, setActiveTab] = useState<'agents' | 'settings'>('agents');
   const [systemPrompt, setSystemPrompt] = useState(project.systemPrompt || '');
   const [defaultModel, setDefaultModel] = useState(stripProviderPrefix(project.defaultProvider || '', project.defaultModel || ''));
@@ -246,38 +248,36 @@ function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSett
   const assignedAgents = allAgents.filter((agent) => project.agentIds?.includes(agent.id));
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <div className="flex items-center gap-2">
-            <FolderKanban className="w-5 h-5 text-primary" />
-            <h2 className="text-lg font-bold">{project.name}</h2>
-          </div>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-        </div>
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <FolderKanban className="w-5 h-5 text-primary" />
+          {project.name}
+        </DialogTitle>
+      </DialogHeader>
 
-        <div className="flex border-b border-border">
-          <button
-            onClick={() => setActiveTab('agents')}
-            className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
-              activeTab === 'agents' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            <Bot className="w-4 h-4" />
-            Agents ({assignedAgents.length})
-          </button>
-          <button
-            onClick={() => setActiveTab('settings')}
-            className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
-              activeTab === 'settings' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            <Settings className="w-4 h-4" />
-            Settings
-          </button>
-        </div>
+      <div className="flex border-b border-border">
+        <button
+          onClick={() => setActiveTab('agents')}
+          className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
+            activeTab === 'agents' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Bot className="w-4 h-4" />
+          Agents ({assignedAgents.length})
+        </button>
+        <button
+          onClick={() => setActiveTab('settings')}
+          className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
+            activeTab === 'settings' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Settings className="w-4 h-4" />
+          Settings
+        </button>
+      </div>
 
-        <div className="flex-grow overflow-y-auto p-6">
+      <div className="flex-grow overflow-y-auto">
           {activeTab === 'agents' ? (
             <AgentAssignmentSection
               allAgents={allAgents}
@@ -296,9 +296,8 @@ function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSett
               onSubmit={handleSettingsSubmit}
             />
           )}
-        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/packages/cli/dist/default/dashboard/app/routes/settings.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/settings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useAction, useMutation, useQuery } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { AlertTriangle, Check, ExternalLink, Key, Loader2, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
 import { deriveGeneralSettings, isSettingsLoaded } from '../lib/settings-helpers';
 
@@ -352,83 +353,81 @@ function SettingsPage() {
           </div>
         )}
 
-        {addingProvider && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Add {addingProvider.name} API Key</h2>
-                <button onClick={() => setAddingProvider(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <div className="p-6 space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Key Name</label>
-                  <input type="text" value={newKeyName} onChange={(event) => setNewKeyName(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Production Key" />
-                </div>
-                <div>
-                  <div className="flex items-center justify-between mb-1">
-                    <label className="text-sm font-medium">API Key</label>
-                    {addingProvider.docsUrl && (
-                      <a href={addingProvider.docsUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Docs <ExternalLink className="w-3 h-3" /></a>
-                    )}
+        <Dialog open={!!addingProvider} onOpenChange={(open) => { if (!open) setAddingProvider(null); }}>
+          <DialogContent className="max-w-md">
+            {addingProvider && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Add {addingProvider.name} API Key</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Key Name</label>
+                    <input type="text" value={newKeyName} onChange={(event) => setNewKeyName(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Production Key" />
                   </div>
-                  <input type="password" value={newKeyValue} onChange={(event) => setNewKeyValue(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder={`${KEY_PREFIXES[addingProvider.id] ?? ''}xxxxxxxxxxxxxxxxxxxx`} />
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-sm font-medium">API Key</label>
+                      {addingProvider.docsUrl && (
+                        <a href={addingProvider.docsUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Docs <ExternalLink className="w-3 h-3" /></a>
+                      )}
+                    </div>
+                    <input type="password" value={newKeyValue} onChange={(event) => setNewKeyValue(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder={`${KEY_PREFIXES[addingProvider.id] ?? ''}xxxxxxxxxxxxxxxxxxxx`} />
+                  </div>
+                  {newKeyValue && KEY_PREFIXES[addingProvider.id] && !newKeyValue.startsWith(KEY_PREFIXES[addingProvider.id]!) && (
+                    <p className="text-xs text-yellow-500 flex items-center gap-1"><AlertTriangle className="w-3.5 h-3.5" /> Key should start with "{KEY_PREFIXES[addingProvider.id]}"</p>
+                  )}
                 </div>
-                {newKeyValue && KEY_PREFIXES[addingProvider.id] && !newKeyValue.startsWith(KEY_PREFIXES[addingProvider.id]!) && (
-                  <p className="text-xs text-yellow-500 flex items-center gap-1"><AlertTriangle className="w-3.5 h-3.5" /> Key should start with "{KEY_PREFIXES[addingProvider.id]}"</p>
-                )}
-              </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setAddingProvider(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleAddKey} disabled={!newKeyValue.trim()} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
-                  <Key className="w-4 h-4" /> Save Key
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+                <DialogFooter>
+                  <button onClick={() => setAddingProvider(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+                  <button onClick={handleAddKey} disabled={!newKeyValue.trim()} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                    <Key className="w-4 h-4" /> Save Key
+                  </button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
 
-        {addingVaultSecret && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Add Secret to Vault</h2>
-                <button onClick={() => setAddingVaultSecret(false)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
+        <Dialog open={addingVaultSecret} onOpenChange={(open) => { if (!open) setAddingVaultSecret(false); }}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Add Secret to Vault</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Name</label>
+                <input type="text" value={vaultForm.name} onChange={(event) => setVaultForm((prev) => ({ ...prev, name: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Database Password" />
               </div>
-              <div className="p-6 space-y-4">
+              <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium mb-1">Name</label>
-                  <input type="text" value={vaultForm.name} onChange={(event) => setVaultForm((prev) => ({ ...prev, name: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Database Password" />
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium mb-1">Category</label>
-                    <select value={vaultForm.category} onChange={(event) => setVaultForm((prev) => ({ ...prev, category: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm">
-                      <option value="api_key">API Key</option>
-                      <option value="token">Token</option>
-                      <option value="credential">Credential</option>
-                      <option value="certificate">Certificate</option>
-                      <option value="other">Other</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1">Provider</label>
-                    <input type="text" value={vaultForm.provider} onChange={(event) => setVaultForm((prev) => ({ ...prev, provider: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. aws" />
-                  </div>
+                  <label className="block text-sm font-medium mb-1">Category</label>
+                  <select value={vaultForm.category} onChange={(event) => setVaultForm((prev) => ({ ...prev, category: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm">
+                    <option value="api_key">API Key</option>
+                    <option value="token">Token</option>
+                    <option value="credential">Credential</option>
+                    <option value="certificate">Certificate</option>
+                    <option value="other">Other</option>
+                  </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium mb-1">Secret Value</label>
-                  <input type="password" value={vaultForm.value} onChange={(event) => setVaultForm((prev) => ({ ...prev, value: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder="Enter the secret value" />
+                  <label className="block text-sm font-medium mb-1">Provider</label>
+                  <input type="text" value={vaultForm.provider} onChange={(event) => setVaultForm((prev) => ({ ...prev, provider: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. aws" />
                 </div>
               </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setAddingVaultSecret(false)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleAddVaultSecret} disabled={!vaultForm.name || !vaultForm.value} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
-                  <Shield className="w-4 h-4" /> Store Secret
-                </button>
+              <div>
+                <label className="block text-sm font-medium mb-1">Secret Value</label>
+                <input type="password" value={vaultForm.value} onChange={(event) => setVaultForm((prev) => ({ ...prev, value: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder="Enter the secret value" />
               </div>
             </div>
-          </div>
-        )}
+            <DialogFooter>
+              <button onClick={() => setAddingVaultSecret(false)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+              <button onClick={handleAddVaultSecret} disabled={!vaultForm.name || !vaultForm.value} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                <Shield className="w-4 h-4" /> Store Secret
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/cli/dist/default/dashboard/app/routes/skills.tsx
+++ b/packages/cli/dist/default/dashboard/app/routes/skills.tsx
@@ -3,7 +3,8 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { Sparkles, Download, Trash2, Plus, Search, X, Check, Code, Globe, Calculator, FileText, Database, Mail, Wrench } from 'lucide-react';
+import { Sparkles, Download, Trash2, Plus, Search, Check, Code, Globe, Calculator, FileText, Database, Mail, Wrench } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/skills')({ component: SkillsPage });
 
@@ -409,23 +410,24 @@ function SkillsPage() {
         )}
 
         {/* Code Preview Modal */}
-        {selectedSkill && (
-          <div key={selectedSkill.name} className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">{selectedSkill.displayName} — Source Code</h2>
-                <button onClick={() => setSelectedSkill(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <pre className="flex-1 overflow-auto p-4 text-xs font-mono bg-background text-foreground">{selectedSkill.code}</pre>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setSelectedSkill(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Close</button>
-                {!installedNames.has(selectedSkill.name) && (
-                  <button onClick={() => { handleInstall(selectedSkill); setSelectedSkill(null); }} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90">Install Skill</button>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
+        <Dialog open={!!selectedSkill} onOpenChange={(open) => { if (!open) setSelectedSkill(null); }}>
+          <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+            {selectedSkill && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>{selectedSkill.displayName} — Source Code</DialogTitle>
+                </DialogHeader>
+                <pre className="flex-1 overflow-auto p-4 text-xs font-mono bg-background text-foreground">{selectedSkill.code}</pre>
+                <DialogFooter>
+                  <button onClick={() => setSelectedSkill(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Close</button>
+                  {!installedNames.has(selectedSkill.name) && (
+                    <button onClick={() => { handleInstall(selectedSkill); setSelectedSkill(null); }} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90">Install Skill</button>
+                  )}
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/cli/templates/default/dashboard/app/routes/agents.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/agents.tsx
@@ -3,7 +3,8 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useState, useMemo, useEffect } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { Bot, Plus, Edit, Trash2, Search, X, Loader2 } from 'lucide-react';
+import { Bot, Plus, Edit, Trash2, Search, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
 
 export const Route = createFileRoute('/agents')({ component: AgentsPage });
@@ -147,24 +148,26 @@ function AgentsPage() {
           </div>
         )}
 
-        {isModalOpen && (
-          <AgentModal
-            key={editingAgent?._id ?? 'create'}
-            agent={editingAgent}
-            modelsByProvider={modelsByProvider}
-            modelsLoading={catalogLoading}
-            onClose={() => { setIsModalOpen(false); setEditingAgent(null); }}
-            onSave={handleSave}
-            providerIds={providerIds}
-            providersById={providersById}
-          />
-        )}
+        <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) { setIsModalOpen(false); setEditingAgent(null); } }}>
+          <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col">
+            <AgentModalContent
+              key={editingAgent?._id ?? 'create'}
+              agent={editingAgent}
+              modelsByProvider={modelsByProvider}
+              modelsLoading={catalogLoading}
+              onClose={() => { setIsModalOpen(false); setEditingAgent(null); }}
+              onSave={handleSave}
+              providerIds={providerIds}
+              providersById={providersById}
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
 }
 
-function AgentModal({
+function AgentModalContent({
   agent,
   onSave,
   onClose,
@@ -257,13 +260,11 @@ function AgentModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex justify-center items-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <h2 className="text-lg font-bold">{agent ? 'Edit Agent' : 'Create Agent'}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-        </div>
-        <form onSubmit={handleSubmit} className="flex-grow overflow-y-auto p-6 space-y-4">
+    <>
+      <DialogHeader>
+        <DialogTitle>{agent ? 'Edit Agent' : 'Create Agent'}</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="flex-grow overflow-y-auto space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Name {formData.name.length}/{VALIDATION.name.maxLength}</label>
             <input
@@ -361,11 +362,10 @@ function AgentModal({
             </div>
           </div>
         </form>
-        <div className="flex justify-end p-4 border-t border-border gap-2">
-          <button type="button" onClick={onClose} className="bg-background border border-border px-4 py-2 rounded-lg hover:bg-muted">Cancel</button>
-          <button type="submit" onClick={handleSubmit} disabled={!formData.name.trim()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed">Save Agent</button>
-        </div>
-      </div>
-    </div>
+      <DialogFooter>
+        <button type="button" onClick={onClose} className="bg-background border border-border px-4 py-2 rounded-lg hover:bg-muted">Cancel</button>
+        <button type="submit" onClick={handleSubmit} disabled={!formData.name.trim()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed">Save Agent</button>
+      </DialogFooter>
+    </>
   );
 }

--- a/packages/cli/templates/default/dashboard/app/routes/connections.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/connections.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useAction } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Plug, Plus, Trash2, Search, X, Check, ExternalLink, Globe, Database, Mail, MessageSquare, FileText, Code, Zap, Shield, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/connections')({ component: ConnectionsPage });
 
@@ -292,44 +293,45 @@ function ConnectionsPage() {
         )}
 
         {/* Connect Modal */}
-        {connectingItem && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Connect {connectingItem.name}</h2>
-                <button onClick={() => setConnectingItem(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <div className="p-6 space-y-4">
-                <p className="text-sm text-muted-foreground">{connectingItem.description}</p>
-                {connectingItem.authFields.length > 0 ? (
-                  <div className="space-y-3">
-                    <h3 className="text-sm font-semibold">Authentication</h3>
-                    {connectingItem.authFields.map(field => (
-                      <div key={field.key}>
-                        <div className="flex items-center justify-between mb-1">
-                          <label className="text-sm font-medium">{field.label}</label>
-                          {field.helpUrl && <a href={field.helpUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Get token <ExternalLink className="w-3 h-3" /></a>}
+        <Dialog open={!!connectingItem} onOpenChange={(open) => { if (!open) setConnectingItem(null); }}>
+          <DialogContent className="max-w-lg">
+            {connectingItem && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Connect {connectingItem.name}</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <p className="text-sm text-muted-foreground">{connectingItem.description}</p>
+                  {connectingItem.authFields.length > 0 ? (
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-semibold">Authentication</h3>
+                      {connectingItem.authFields.map(field => (
+                        <div key={field.key}>
+                          <div className="flex items-center justify-between mb-1">
+                            <label className="text-sm font-medium">{field.label}</label>
+                            {field.helpUrl && <a href={field.helpUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Get token <ExternalLink className="w-3 h-3" /></a>}
+                          </div>
+                          <input type="password" placeholder={field.placeholder} value={authValues[field.key] || ''} onChange={(e) => setAuthValues(prev => ({ ...prev, [field.key]: e.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary font-mono" />
                         </div>
-                        <input type="password" placeholder={field.placeholder} value={authValues[field.key] || ''} onChange={(e) => setAuthValues(prev => ({ ...prev, [field.key]: e.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary font-mono" />
-                      </div>
-                    ))}
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-green-500">No authentication required for this integration.</p>
+                  )}
+                  <div className="bg-muted/50 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground font-mono">{connectingItem.serverUrl}</p>
                   </div>
-                ) : (
-                  <p className="text-sm text-green-500">No authentication required for this integration.</p>
-                )}
-                <div className="bg-muted/50 rounded-lg p-3">
-                  <p className="text-xs text-muted-foreground font-mono">{connectingItem.serverUrl}</p>
                 </div>
-              </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setConnectingItem(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleConnect} disabled={connectingItem.authFields.length > 0 && connectingItem.authFields.some(f => !authValues[f.key])} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
-                  <Plug className="w-4 h-4" /> Connect
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+                <DialogFooter>
+                  <button onClick={() => setConnectingItem(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+                  <button onClick={handleConnect} disabled={connectingItem.authFields.length > 0 && connectingItem.authFields.some(f => !authValues[f.key])} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
+                    <Plug className="w-4 h-4" /> Connect
+                  </button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/cli/templates/default/dashboard/app/routes/cron.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/cron.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Clock, Play, Pause, Plus, History, Trash2, Edit, X, AlertCircle, CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/cron')({ component: CronPage });
 
@@ -185,12 +186,16 @@ function CronPage() {
           </div>
         )}
 
-        {isCreateModalOpen && (
-          <CronModal agents={agents} onSave={handleCreate} onClose={() => setIsCreateModalOpen(false)} />
-        )}
-        {editingJob && (
-          <CronModal agents={agents} job={editingJob} onSave={handleEdit} onClose={() => setEditingJob(null)} />
-        )}
+        <Dialog open={isCreateModalOpen} onOpenChange={(open) => { if (!open) setIsCreateModalOpen(false); }}>
+          <DialogContent className="max-w-lg">
+            <CronModalContent agents={agents} onSave={handleCreate} onClose={() => setIsCreateModalOpen(false)} />
+          </DialogContent>
+        </Dialog>
+        <Dialog open={!!editingJob} onOpenChange={(open) => { if (!open) setEditingJob(null); }}>
+          <DialogContent className="max-w-lg">
+            {editingJob && <CronModalContent agents={agents} job={editingJob} onSave={handleEdit} onClose={() => setEditingJob(null)} />}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
@@ -240,7 +245,7 @@ function RunHistoryPanel({ cronJobId, onClose }: { cronJobId: any; onClose: () =
   );
 }
 
-function CronModal({
+function CronModalContent({
   agents,
   job,
   onSave,
@@ -283,15 +288,11 @@ function CronModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <h2 className="text-lg font-bold">{job ? 'Edit Scheduled Task' : 'New Scheduled Task'}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+    <>
+      <DialogHeader>
+        <DialogTitle>{job ? 'Edit Scheduled Task' : 'New Scheduled Task'}</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Name</label>
             <input
@@ -370,19 +371,18 @@ function CronModal({
             />
           </div>
         </form>
-        <div className="p-4 border-t border-border flex justify-end gap-2">
-          <button onClick={onClose} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">
-            Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!form.name || !form.agentId || !form.prompt}
-            className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
-          >
-            {job ? 'Update Schedule' : 'Create Schedule'}
-          </button>
-        </div>
-      </div>
-    </div>
+      <DialogFooter>
+        <button onClick={onClose} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">
+          Cancel
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={!form.name || !form.agentId || !form.prompt}
+          className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
+        >
+          {job ? 'Update Schedule' : 'Create Schedule'}
+        </button>
+      </DialogFooter>
+    </>
   );
 }

--- a/packages/cli/templates/default/dashboard/app/routes/projects.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/projects.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Id } from '@convex/_generated/dataModel';
 import { FolderKanban, Plus, Trash2, Edit, Search, X, Bot, Settings, Check } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog } from '../lib/model-catalog';
 
 export const Route = createFileRoute('/projects')({ component: ProjectsPage });
@@ -163,28 +164,29 @@ function ProjectsPage() {
           </div>
         )}
 
-        {isModalOpen && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">{editingProject ? 'Edit Project' : 'New Project'}</h2>
-                <button onClick={() => { setIsModalOpen(false); setEditingProject(null); }} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <ProjectForm key={editingProject?._id ?? 'create'} initial={editingProject} onSave={handleSave} onClose={() => { setIsModalOpen(false); setEditingProject(null); }} />
-            </div>
-          </div>
-        )}
+        <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) { setIsModalOpen(false); setEditingProject(null); } }}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>{editingProject ? 'Edit Project' : 'New Project'}</DialogTitle>
+            </DialogHeader>
+            <ProjectForm key={editingProject?._id ?? 'create'} initial={editingProject} onSave={handleSave} onClose={() => { setIsModalOpen(false); setEditingProject(null); }} />
+          </DialogContent>
+        </Dialog>
 
-        {isDetailOpen && detailProject && (
-          <ProjectDetailModal
-            project={detailProject}
-            allAgents={allAgents}
-            onClose={() => { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); }}
-            onToggleAgent={handleToggleAgent}
-            onSettingsSave={handleSettingsSave}
-            confirmingUnassignAgentId={confirmingUnassignAgentId}
-          />
-        )}
+        <Dialog open={isDetailOpen && !!detailProject} onOpenChange={(open) => { if (!open) { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); } }}>
+          <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col">
+            {detailProject && (
+              <ProjectDetailContent
+                project={detailProject}
+                allAgents={allAgents}
+                onClose={() => { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); }}
+                onToggleAgent={handleToggleAgent}
+                onSettingsSave={handleSettingsSave}
+                confirmingUnassignAgentId={confirmingUnassignAgentId}
+              />
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
@@ -219,7 +221,7 @@ function ProjectForm({ initial, onSave, onClose }: { initial: any; onSave: (data
   );
 }
 
-interface ProjectDetailModalProps {
+interface ProjectDetailContentProps {
   project: any;
   allAgents: any[];
   onClose: () => void;
@@ -228,7 +230,7 @@ interface ProjectDetailModalProps {
   confirmingUnassignAgentId: string | null;
 }
 
-function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSettingsSave, confirmingUnassignAgentId }: ProjectDetailModalProps) {
+function ProjectDetailContent({ project, allAgents, onClose, onToggleAgent, onSettingsSave, confirmingUnassignAgentId }: ProjectDetailContentProps) {
   const [activeTab, setActiveTab] = useState<'agents' | 'settings'>('agents');
   const [systemPrompt, setSystemPrompt] = useState(project.systemPrompt || '');
   const [defaultModel, setDefaultModel] = useState(stripProviderPrefix(project.defaultProvider || '', project.defaultModel || ''));
@@ -246,38 +248,36 @@ function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSett
   const assignedAgents = allAgents.filter((agent) => project.agentIds?.includes(agent.id));
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <div className="flex items-center gap-2">
-            <FolderKanban className="w-5 h-5 text-primary" />
-            <h2 className="text-lg font-bold">{project.name}</h2>
-          </div>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-        </div>
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <FolderKanban className="w-5 h-5 text-primary" />
+          {project.name}
+        </DialogTitle>
+      </DialogHeader>
 
-        <div className="flex border-b border-border">
-          <button
-            onClick={() => setActiveTab('agents')}
-            className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
-              activeTab === 'agents' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            <Bot className="w-4 h-4" />
-            Agents ({assignedAgents.length})
-          </button>
-          <button
-            onClick={() => setActiveTab('settings')}
-            className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
-              activeTab === 'settings' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            <Settings className="w-4 h-4" />
-            Settings
-          </button>
-        </div>
+      <div className="flex border-b border-border">
+        <button
+          onClick={() => setActiveTab('agents')}
+          className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
+            activeTab === 'agents' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Bot className="w-4 h-4" />
+          Agents ({assignedAgents.length})
+        </button>
+        <button
+          onClick={() => setActiveTab('settings')}
+          className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
+            activeTab === 'settings' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Settings className="w-4 h-4" />
+          Settings
+        </button>
+      </div>
 
-        <div className="flex-grow overflow-y-auto p-6">
+      <div className="flex-grow overflow-y-auto">
           {activeTab === 'agents' ? (
             <AgentAssignmentSection
               allAgents={allAgents}
@@ -296,9 +296,8 @@ function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSett
               onSubmit={handleSettingsSubmit}
             />
           )}
-        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/packages/cli/templates/default/dashboard/app/routes/settings.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/settings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useAction, useMutation, useQuery } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { AlertTriangle, Check, ExternalLink, Key, Loader2, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
 import { deriveGeneralSettings, isSettingsLoaded } from '../lib/settings-helpers';
 
@@ -352,83 +353,81 @@ function SettingsPage() {
           </div>
         )}
 
-        {addingProvider && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Add {addingProvider.name} API Key</h2>
-                <button onClick={() => setAddingProvider(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <div className="p-6 space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Key Name</label>
-                  <input type="text" value={newKeyName} onChange={(event) => setNewKeyName(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Production Key" />
-                </div>
-                <div>
-                  <div className="flex items-center justify-between mb-1">
-                    <label className="text-sm font-medium">API Key</label>
-                    {addingProvider.docsUrl && (
-                      <a href={addingProvider.docsUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Docs <ExternalLink className="w-3 h-3" /></a>
-                    )}
+        <Dialog open={!!addingProvider} onOpenChange={(open) => { if (!open) setAddingProvider(null); }}>
+          <DialogContent className="max-w-md">
+            {addingProvider && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Add {addingProvider.name} API Key</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Key Name</label>
+                    <input type="text" value={newKeyName} onChange={(event) => setNewKeyName(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Production Key" />
                   </div>
-                  <input type="password" value={newKeyValue} onChange={(event) => setNewKeyValue(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder={`${KEY_PREFIXES[addingProvider.id] ?? ''}xxxxxxxxxxxxxxxxxxxx`} />
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-sm font-medium">API Key</label>
+                      {addingProvider.docsUrl && (
+                        <a href={addingProvider.docsUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Docs <ExternalLink className="w-3 h-3" /></a>
+                      )}
+                    </div>
+                    <input type="password" value={newKeyValue} onChange={(event) => setNewKeyValue(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder={`${KEY_PREFIXES[addingProvider.id] ?? ''}xxxxxxxxxxxxxxxxxxxx`} />
+                  </div>
+                  {newKeyValue && KEY_PREFIXES[addingProvider.id] && !newKeyValue.startsWith(KEY_PREFIXES[addingProvider.id]!) && (
+                    <p className="text-xs text-yellow-500 flex items-center gap-1"><AlertTriangle className="w-3.5 h-3.5" /> Key should start with "{KEY_PREFIXES[addingProvider.id]}"</p>
+                  )}
                 </div>
-                {newKeyValue && KEY_PREFIXES[addingProvider.id] && !newKeyValue.startsWith(KEY_PREFIXES[addingProvider.id]!) && (
-                  <p className="text-xs text-yellow-500 flex items-center gap-1"><AlertTriangle className="w-3.5 h-3.5" /> Key should start with "{KEY_PREFIXES[addingProvider.id]}"</p>
-                )}
-              </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setAddingProvider(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleAddKey} disabled={!newKeyValue.trim()} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
-                  <Key className="w-4 h-4" /> Save Key
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+                <DialogFooter>
+                  <button onClick={() => setAddingProvider(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+                  <button onClick={handleAddKey} disabled={!newKeyValue.trim()} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                    <Key className="w-4 h-4" /> Save Key
+                  </button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
 
-        {addingVaultSecret && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Add Secret to Vault</h2>
-                <button onClick={() => setAddingVaultSecret(false)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
+        <Dialog open={addingVaultSecret} onOpenChange={(open) => { if (!open) setAddingVaultSecret(false); }}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Add Secret to Vault</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Name</label>
+                <input type="text" value={vaultForm.name} onChange={(event) => setVaultForm((prev) => ({ ...prev, name: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Database Password" />
               </div>
-              <div className="p-6 space-y-4">
+              <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium mb-1">Name</label>
-                  <input type="text" value={vaultForm.name} onChange={(event) => setVaultForm((prev) => ({ ...prev, name: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Database Password" />
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium mb-1">Category</label>
-                    <select value={vaultForm.category} onChange={(event) => setVaultForm((prev) => ({ ...prev, category: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm">
-                      <option value="api_key">API Key</option>
-                      <option value="token">Token</option>
-                      <option value="credential">Credential</option>
-                      <option value="certificate">Certificate</option>
-                      <option value="other">Other</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1">Provider</label>
-                    <input type="text" value={vaultForm.provider} onChange={(event) => setVaultForm((prev) => ({ ...prev, provider: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. aws" />
-                  </div>
+                  <label className="block text-sm font-medium mb-1">Category</label>
+                  <select value={vaultForm.category} onChange={(event) => setVaultForm((prev) => ({ ...prev, category: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm">
+                    <option value="api_key">API Key</option>
+                    <option value="token">Token</option>
+                    <option value="credential">Credential</option>
+                    <option value="certificate">Certificate</option>
+                    <option value="other">Other</option>
+                  </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium mb-1">Secret Value</label>
-                  <input type="password" value={vaultForm.value} onChange={(event) => setVaultForm((prev) => ({ ...prev, value: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder="Enter the secret value" />
+                  <label className="block text-sm font-medium mb-1">Provider</label>
+                  <input type="text" value={vaultForm.provider} onChange={(event) => setVaultForm((prev) => ({ ...prev, provider: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. aws" />
                 </div>
               </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setAddingVaultSecret(false)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleAddVaultSecret} disabled={!vaultForm.name || !vaultForm.value} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
-                  <Shield className="w-4 h-4" /> Store Secret
-                </button>
+              <div>
+                <label className="block text-sm font-medium mb-1">Secret Value</label>
+                <input type="password" value={vaultForm.value} onChange={(event) => setVaultForm((prev) => ({ ...prev, value: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder="Enter the secret value" />
               </div>
             </div>
-          </div>
-        )}
+            <DialogFooter>
+              <button onClick={() => setAddingVaultSecret(false)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+              <button onClick={handleAddVaultSecret} disabled={!vaultForm.name || !vaultForm.value} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                <Shield className="w-4 h-4" /> Store Secret
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/cli/templates/default/dashboard/app/routes/skills.tsx
+++ b/packages/cli/templates/default/dashboard/app/routes/skills.tsx
@@ -3,7 +3,8 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { Sparkles, Download, Trash2, Plus, Search, X, Check, Code, Globe, Calculator, FileText, Database, Mail, Wrench } from 'lucide-react';
+import { Sparkles, Download, Trash2, Plus, Search, Check, Code, Globe, Calculator, FileText, Database, Mail, Wrench } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/skills')({ component: SkillsPage });
 
@@ -409,23 +410,24 @@ function SkillsPage() {
         )}
 
         {/* Code Preview Modal */}
-        {selectedSkill && (
-          <div key={selectedSkill.name} className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">{selectedSkill.displayName} — Source Code</h2>
-                <button onClick={() => setSelectedSkill(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <pre className="flex-1 overflow-auto p-4 text-xs font-mono bg-background text-foreground">{selectedSkill.code}</pre>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setSelectedSkill(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Close</button>
-                {!installedNames.has(selectedSkill.name) && (
-                  <button onClick={() => { handleInstall(selectedSkill); setSelectedSkill(null); }} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90">Install Skill</button>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
+        <Dialog open={!!selectedSkill} onOpenChange={(open) => { if (!open) setSelectedSkill(null); }}>
+          <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+            {selectedSkill && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>{selectedSkill.displayName} — Source Code</DialogTitle>
+                </DialogHeader>
+                <pre className="flex-1 overflow-auto p-4 text-xs font-mono bg-background text-foreground">{selectedSkill.code}</pre>
+                <DialogFooter>
+                  <button onClick={() => setSelectedSkill(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Close</button>
+                  {!installedNames.has(selectedSkill.name) && (
+                    <button onClick={() => { handleInstall(selectedSkill); setSelectedSkill(null); }} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90">Install Skill</button>
+                  )}
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/web/app/routes/agents.tsx
+++ b/packages/web/app/routes/agents.tsx
@@ -3,7 +3,8 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useState, useMemo, useEffect } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { Bot, Plus, Edit, Trash2, Search, X, Loader2 } from 'lucide-react';
+import { Bot, Plus, Edit, Trash2, Search, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
 
 export const Route = createFileRoute('/agents')({ component: AgentsPage });
@@ -147,24 +148,26 @@ function AgentsPage() {
           </div>
         )}
 
-        {isModalOpen && (
-          <AgentModal
-            key={editingAgent?._id ?? 'create'}
-            agent={editingAgent}
-            modelsByProvider={modelsByProvider}
-            modelsLoading={catalogLoading}
-            onClose={() => { setIsModalOpen(false); setEditingAgent(null); }}
-            onSave={handleSave}
-            providerIds={providerIds}
-            providersById={providersById}
-          />
-        )}
+        <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) { setIsModalOpen(false); setEditingAgent(null); } }}>
+          <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col">
+            <AgentModalContent
+              key={editingAgent?._id ?? 'create'}
+              agent={editingAgent}
+              modelsByProvider={modelsByProvider}
+              modelsLoading={catalogLoading}
+              onClose={() => { setIsModalOpen(false); setEditingAgent(null); }}
+              onSave={handleSave}
+              providerIds={providerIds}
+              providersById={providersById}
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
 }
 
-function AgentModal({
+function AgentModalContent({
   agent,
   onSave,
   onClose,
@@ -257,13 +260,11 @@ function AgentModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex justify-center items-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <h2 className="text-lg font-bold">{agent ? 'Edit Agent' : 'Create Agent'}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-        </div>
-        <form onSubmit={handleSubmit} className="flex-grow overflow-y-auto p-6 space-y-4">
+    <>
+      <DialogHeader>
+        <DialogTitle>{agent ? 'Edit Agent' : 'Create Agent'}</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="flex-grow overflow-y-auto space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Name {formData.name.length}/{VALIDATION.name.maxLength}</label>
             <input
@@ -361,11 +362,10 @@ function AgentModal({
             </div>
           </div>
         </form>
-        <div className="flex justify-end p-4 border-t border-border gap-2">
-          <button type="button" onClick={onClose} className="bg-background border border-border px-4 py-2 rounded-lg hover:bg-muted">Cancel</button>
-          <button type="submit" onClick={handleSubmit} disabled={!formData.name.trim()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed">Save Agent</button>
-        </div>
-      </div>
-    </div>
+      <DialogFooter>
+        <button type="button" onClick={onClose} className="bg-background border border-border px-4 py-2 rounded-lg hover:bg-muted">Cancel</button>
+        <button type="submit" onClick={handleSubmit} disabled={!formData.name.trim()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed">Save Agent</button>
+      </DialogFooter>
+    </>
   );
 }

--- a/packages/web/app/routes/connections.tsx
+++ b/packages/web/app/routes/connections.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useAction } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Plug, Plus, Trash2, Search, X, Check, ExternalLink, Globe, Database, Mail, MessageSquare, FileText, Code, Zap, Shield, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/connections')({ component: ConnectionsPage });
 
@@ -292,44 +293,45 @@ function ConnectionsPage() {
         )}
 
         {/* Connect Modal */}
-        {connectingItem && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Connect {connectingItem.name}</h2>
-                <button onClick={() => setConnectingItem(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <div className="p-6 space-y-4">
-                <p className="text-sm text-muted-foreground">{connectingItem.description}</p>
-                {connectingItem.authFields.length > 0 ? (
-                  <div className="space-y-3">
-                    <h3 className="text-sm font-semibold">Authentication</h3>
-                    {connectingItem.authFields.map(field => (
-                      <div key={field.key}>
-                        <div className="flex items-center justify-between mb-1">
-                          <label className="text-sm font-medium">{field.label}</label>
-                          {field.helpUrl && <a href={field.helpUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Get token <ExternalLink className="w-3 h-3" /></a>}
+        <Dialog open={!!connectingItem} onOpenChange={(open) => { if (!open) setConnectingItem(null); }}>
+          <DialogContent className="max-w-lg">
+            {connectingItem && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Connect {connectingItem.name}</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <p className="text-sm text-muted-foreground">{connectingItem.description}</p>
+                  {connectingItem.authFields.length > 0 ? (
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-semibold">Authentication</h3>
+                      {connectingItem.authFields.map(field => (
+                        <div key={field.key}>
+                          <div className="flex items-center justify-between mb-1">
+                            <label className="text-sm font-medium">{field.label}</label>
+                            {field.helpUrl && <a href={field.helpUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Get token <ExternalLink className="w-3 h-3" /></a>}
+                          </div>
+                          <input type="password" placeholder={field.placeholder} value={authValues[field.key] || ''} onChange={(e) => setAuthValues(prev => ({ ...prev, [field.key]: e.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary font-mono" />
                         </div>
-                        <input type="password" placeholder={field.placeholder} value={authValues[field.key] || ''} onChange={(e) => setAuthValues(prev => ({ ...prev, [field.key]: e.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary font-mono" />
-                      </div>
-                    ))}
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-green-500">No authentication required for this integration.</p>
+                  )}
+                  <div className="bg-muted/50 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground font-mono">{connectingItem.serverUrl}</p>
                   </div>
-                ) : (
-                  <p className="text-sm text-green-500">No authentication required for this integration.</p>
-                )}
-                <div className="bg-muted/50 rounded-lg p-3">
-                  <p className="text-xs text-muted-foreground font-mono">{connectingItem.serverUrl}</p>
                 </div>
-              </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setConnectingItem(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleConnect} disabled={connectingItem.authFields.length > 0 && connectingItem.authFields.some(f => !authValues[f.key])} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
-                  <Plug className="w-4 h-4" /> Connect
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+                <DialogFooter>
+                  <button onClick={() => setConnectingItem(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+                  <button onClick={handleConnect} disabled={connectingItem.authFields.length > 0 && connectingItem.authFields.some(f => !authValues[f.key])} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
+                    <Plug className="w-4 h-4" /> Connect
+                  </button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/web/app/routes/cron.tsx
+++ b/packages/web/app/routes/cron.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Clock, Play, Pause, Plus, History, Trash2, Edit, X, AlertCircle, CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/cron')({ component: CronPage });
 
@@ -185,12 +186,16 @@ function CronPage() {
           </div>
         )}
 
-        {isCreateModalOpen && (
-          <CronModal agents={agents} onSave={handleCreate} onClose={() => setIsCreateModalOpen(false)} />
-        )}
-        {editingJob && (
-          <CronModal agents={agents} job={editingJob} onSave={handleEdit} onClose={() => setEditingJob(null)} />
-        )}
+        <Dialog open={isCreateModalOpen} onOpenChange={(open) => { if (!open) setIsCreateModalOpen(false); }}>
+          <DialogContent className="max-w-lg">
+            <CronModalContent agents={agents} onSave={handleCreate} onClose={() => setIsCreateModalOpen(false)} />
+          </DialogContent>
+        </Dialog>
+        <Dialog open={!!editingJob} onOpenChange={(open) => { if (!open) setEditingJob(null); }}>
+          <DialogContent className="max-w-lg">
+            {editingJob && <CronModalContent agents={agents} job={editingJob} onSave={handleEdit} onClose={() => setEditingJob(null)} />}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
@@ -240,7 +245,7 @@ function RunHistoryPanel({ cronJobId, onClose }: { cronJobId: any; onClose: () =
   );
 }
 
-function CronModal({
+function CronModalContent({
   agents,
   job,
   onSave,
@@ -283,15 +288,11 @@ function CronModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <h2 className="text-lg font-bold">{job ? 'Edit Scheduled Task' : 'New Scheduled Task'}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+    <>
+      <DialogHeader>
+        <DialogTitle>{job ? 'Edit Scheduled Task' : 'New Scheduled Task'}</DialogTitle>
+      </DialogHeader>
+      <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Name</label>
             <input
@@ -370,19 +371,18 @@ function CronModal({
             />
           </div>
         </form>
-        <div className="p-4 border-t border-border flex justify-end gap-2">
-          <button onClick={onClose} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">
-            Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!form.name || !form.agentId || !form.prompt}
-            className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
-          >
-            {job ? 'Update Schedule' : 'Create Schedule'}
-          </button>
-        </div>
-      </div>
-    </div>
+      <DialogFooter>
+        <button onClick={onClose} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">
+          Cancel
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={!form.name || !form.agentId || !form.prompt}
+          className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
+        >
+          {job ? 'Update Schedule' : 'Create Schedule'}
+        </button>
+      </DialogFooter>
+    </>
   );
 }

--- a/packages/web/app/routes/modal-pattern.test.ts
+++ b/packages/web/app/routes/modal-pattern.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROUTES_DIR = path.resolve(import.meta.dirname, '.');
+
+const ROUTES_WITH_MODALS = [
+  'agents.tsx',
+  'connections.tsx',
+  'cron.tsx',
+  'projects.tsx',
+  'settings.tsx',
+  'skills.tsx',
+];
+
+const HAND_ROLLED_PATTERN = /className="fixed inset-0 bg-black/;
+
+describe('modal pattern enforcement', () => {
+  for (const routeFile of ROUTES_WITH_MODALS) {
+    it(`${routeFile} should use Radix Dialog, not hand-rolled overlay`, () => {
+      const filePath = path.join(ROUTES_DIR, routeFile);
+      const source = fs.readFileSync(filePath, 'utf-8');
+
+      const handRolledCount = (source.match(HAND_ROLLED_PATTERN) || []).length;
+      expect(
+        handRolledCount,
+        `${routeFile} has ${handRolledCount} hand-rolled modal overlay(s). Use <Dialog>/<DialogContent> from components/ui/dialog instead.`,
+      ).toBe(0);
+    });
+  }
+
+  for (const routeFile of ROUTES_WITH_MODALS) {
+    it(`${routeFile} should import from components/ui/dialog`, () => {
+      const filePath = path.join(ROUTES_DIR, routeFile);
+      const source = fs.readFileSync(filePath, 'utf-8');
+
+      expect(
+        source,
+        `${routeFile} should import Dialog primitives from components/ui/dialog`,
+      ).toContain("from '../components/ui/dialog'");
+    });
+  }
+});

--- a/packages/web/app/routes/projects.tsx
+++ b/packages/web/app/routes/projects.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { Id } from '@convex/_generated/dataModel';
 import { FolderKanban, Plus, Trash2, Edit, Search, X, Bot, Settings, Check } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog } from '../lib/model-catalog';
 
 export const Route = createFileRoute('/projects')({ component: ProjectsPage });
@@ -163,28 +164,29 @@ function ProjectsPage() {
           </div>
         )}
 
-        {isModalOpen && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">{editingProject ? 'Edit Project' : 'New Project'}</h2>
-                <button onClick={() => { setIsModalOpen(false); setEditingProject(null); }} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <ProjectForm key={editingProject?._id ?? 'create'} initial={editingProject} onSave={handleSave} onClose={() => { setIsModalOpen(false); setEditingProject(null); }} />
-            </div>
-          </div>
-        )}
+        <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) { setIsModalOpen(false); setEditingProject(null); } }}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>{editingProject ? 'Edit Project' : 'New Project'}</DialogTitle>
+            </DialogHeader>
+            <ProjectForm key={editingProject?._id ?? 'create'} initial={editingProject} onSave={handleSave} onClose={() => { setIsModalOpen(false); setEditingProject(null); }} />
+          </DialogContent>
+        </Dialog>
 
-        {isDetailOpen && detailProject && (
-          <ProjectDetailModal
-            project={detailProject}
-            allAgents={allAgents}
-            onClose={() => { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); }}
-            onToggleAgent={handleToggleAgent}
-            onSettingsSave={handleSettingsSave}
-            confirmingUnassignAgentId={confirmingUnassignAgentId}
-          />
-        )}
+        <Dialog open={isDetailOpen && !!detailProject} onOpenChange={(open) => { if (!open) { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); } }}>
+          <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col">
+            {detailProject && (
+              <ProjectDetailContent
+                project={detailProject}
+                allAgents={allAgents}
+                onClose={() => { setIsDetailOpen(false); setDetailProjectId(null); setConfirmingUnassignAgentId(null); }}
+                onToggleAgent={handleToggleAgent}
+                onSettingsSave={handleSettingsSave}
+                confirmingUnassignAgentId={confirmingUnassignAgentId}
+              />
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
@@ -219,7 +221,7 @@ function ProjectForm({ initial, onSave, onClose }: { initial: any; onSave: (data
   );
 }
 
-interface ProjectDetailModalProps {
+interface ProjectDetailContentProps {
   project: any;
   allAgents: any[];
   onClose: () => void;
@@ -228,7 +230,7 @@ interface ProjectDetailModalProps {
   confirmingUnassignAgentId: string | null;
 }
 
-function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSettingsSave, confirmingUnassignAgentId }: ProjectDetailModalProps) {
+function ProjectDetailContent({ project, allAgents, onClose, onToggleAgent, onSettingsSave, confirmingUnassignAgentId }: ProjectDetailContentProps) {
   const [activeTab, setActiveTab] = useState<'agents' | 'settings'>('agents');
   const [systemPrompt, setSystemPrompt] = useState(project.systemPrompt || '');
   const [defaultModel, setDefaultModel] = useState(stripProviderPrefix(project.defaultProvider || '', project.defaultModel || ''));
@@ -246,38 +248,36 @@ function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSett
   const assignedAgents = allAgents.filter((agent) => project.agentIds?.includes(agent.id));
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <div className="flex justify-between items-center p-4 border-b border-border">
-          <div className="flex items-center gap-2">
-            <FolderKanban className="w-5 h-5 text-primary" />
-            <h2 className="text-lg font-bold">{project.name}</h2>
-          </div>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-        </div>
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <FolderKanban className="w-5 h-5 text-primary" />
+          {project.name}
+        </DialogTitle>
+      </DialogHeader>
 
-        <div className="flex border-b border-border">
-          <button
-            onClick={() => setActiveTab('agents')}
-            className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
-              activeTab === 'agents' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            <Bot className="w-4 h-4" />
-            Agents ({assignedAgents.length})
-          </button>
-          <button
-            onClick={() => setActiveTab('settings')}
-            className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
-              activeTab === 'settings' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            <Settings className="w-4 h-4" />
-            Settings
-          </button>
-        </div>
+      <div className="flex border-b border-border">
+        <button
+          onClick={() => setActiveTab('agents')}
+          className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
+            activeTab === 'agents' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Bot className="w-4 h-4" />
+          Agents ({assignedAgents.length})
+        </button>
+        <button
+          onClick={() => setActiveTab('settings')}
+          className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
+            activeTab === 'settings' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Settings className="w-4 h-4" />
+          Settings
+        </button>
+      </div>
 
-        <div className="flex-grow overflow-y-auto p-6">
+      <div className="flex-grow overflow-y-auto">
           {activeTab === 'agents' ? (
             <AgentAssignmentSection
               allAgents={allAgents}
@@ -296,9 +296,8 @@ function ProjectDetailModal({ project, allAgents, onClose, onToggleAgent, onSett
               onSubmit={handleSettingsSubmit}
             />
           )}
-        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/packages/web/app/routes/settings.tsx
+++ b/packages/web/app/routes/settings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useAction, useMutation, useQuery } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { AlertTriangle, Check, ExternalLink, Key, Loader2, Plus, Settings, Shield, Trash2, X } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { useModelCatalog, type ProviderCatalogEntry } from '../lib/model-catalog';
 import { deriveGeneralSettings, isSettingsLoaded } from '../lib/settings-helpers';
 
@@ -352,83 +353,81 @@ function SettingsPage() {
           </div>
         )}
 
-        {addingProvider && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Add {addingProvider.name} API Key</h2>
-                <button onClick={() => setAddingProvider(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <div className="p-6 space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Key Name</label>
-                  <input type="text" value={newKeyName} onChange={(event) => setNewKeyName(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Production Key" />
-                </div>
-                <div>
-                  <div className="flex items-center justify-between mb-1">
-                    <label className="text-sm font-medium">API Key</label>
-                    {addingProvider.docsUrl && (
-                      <a href={addingProvider.docsUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Docs <ExternalLink className="w-3 h-3" /></a>
-                    )}
+        <Dialog open={!!addingProvider} onOpenChange={(open) => { if (!open) setAddingProvider(null); }}>
+          <DialogContent className="max-w-md">
+            {addingProvider && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Add {addingProvider.name} API Key</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Key Name</label>
+                    <input type="text" value={newKeyName} onChange={(event) => setNewKeyName(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Production Key" />
                   </div>
-                  <input type="password" value={newKeyValue} onChange={(event) => setNewKeyValue(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder={`${KEY_PREFIXES[addingProvider.id] ?? ''}xxxxxxxxxxxxxxxxxxxx`} />
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-sm font-medium">API Key</label>
+                      {addingProvider.docsUrl && (
+                        <a href={addingProvider.docsUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">Docs <ExternalLink className="w-3 h-3" /></a>
+                      )}
+                    </div>
+                    <input type="password" value={newKeyValue} onChange={(event) => setNewKeyValue(event.target.value)} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder={`${KEY_PREFIXES[addingProvider.id] ?? ''}xxxxxxxxxxxxxxxxxxxx`} />
+                  </div>
+                  {newKeyValue && KEY_PREFIXES[addingProvider.id] && !newKeyValue.startsWith(KEY_PREFIXES[addingProvider.id]!) && (
+                    <p className="text-xs text-yellow-500 flex items-center gap-1"><AlertTriangle className="w-3.5 h-3.5" /> Key should start with "{KEY_PREFIXES[addingProvider.id]}"</p>
+                  )}
                 </div>
-                {newKeyValue && KEY_PREFIXES[addingProvider.id] && !newKeyValue.startsWith(KEY_PREFIXES[addingProvider.id]!) && (
-                  <p className="text-xs text-yellow-500 flex items-center gap-1"><AlertTriangle className="w-3.5 h-3.5" /> Key should start with "{KEY_PREFIXES[addingProvider.id]}"</p>
-                )}
-              </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setAddingProvider(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleAddKey} disabled={!newKeyValue.trim()} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
-                  <Key className="w-4 h-4" /> Save Key
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+                <DialogFooter>
+                  <button onClick={() => setAddingProvider(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+                  <button onClick={handleAddKey} disabled={!newKeyValue.trim()} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                    <Key className="w-4 h-4" /> Save Key
+                  </button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
 
-        {addingVaultSecret && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">Add Secret to Vault</h2>
-                <button onClick={() => setAddingVaultSecret(false)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
+        <Dialog open={addingVaultSecret} onOpenChange={(open) => { if (!open) setAddingVaultSecret(false); }}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Add Secret to Vault</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Name</label>
+                <input type="text" value={vaultForm.name} onChange={(event) => setVaultForm((prev) => ({ ...prev, name: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Database Password" />
               </div>
-              <div className="p-6 space-y-4">
+              <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium mb-1">Name</label>
-                  <input type="text" value={vaultForm.name} onChange={(event) => setVaultForm((prev) => ({ ...prev, name: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. Database Password" />
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium mb-1">Category</label>
-                    <select value={vaultForm.category} onChange={(event) => setVaultForm((prev) => ({ ...prev, category: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm">
-                      <option value="api_key">API Key</option>
-                      <option value="token">Token</option>
-                      <option value="credential">Credential</option>
-                      <option value="certificate">Certificate</option>
-                      <option value="other">Other</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1">Provider</label>
-                    <input type="text" value={vaultForm.provider} onChange={(event) => setVaultForm((prev) => ({ ...prev, provider: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. aws" />
-                  </div>
+                  <label className="block text-sm font-medium mb-1">Category</label>
+                  <select value={vaultForm.category} onChange={(event) => setVaultForm((prev) => ({ ...prev, category: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm">
+                    <option value="api_key">API Key</option>
+                    <option value="token">Token</option>
+                    <option value="credential">Credential</option>
+                    <option value="certificate">Certificate</option>
+                    <option value="other">Other</option>
+                  </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium mb-1">Secret Value</label>
-                  <input type="password" value={vaultForm.value} onChange={(event) => setVaultForm((prev) => ({ ...prev, value: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder="Enter the secret value" />
+                  <label className="block text-sm font-medium mb-1">Provider</label>
+                  <input type="text" value={vaultForm.provider} onChange={(event) => setVaultForm((prev) => ({ ...prev, provider: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm" placeholder="e.g. aws" />
                 </div>
               </div>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setAddingVaultSecret(false)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
-                <button onClick={handleAddVaultSecret} disabled={!vaultForm.name || !vaultForm.value} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
-                  <Shield className="w-4 h-4" /> Store Secret
-                </button>
+              <div>
+                <label className="block text-sm font-medium mb-1">Secret Value</label>
+                <input type="password" value={vaultForm.value} onChange={(event) => setVaultForm((prev) => ({ ...prev, value: event.target.value }))} className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono" placeholder="Enter the secret value" />
               </div>
             </div>
-          </div>
-        )}
+            <DialogFooter>
+              <button onClick={() => setAddingVaultSecret(false)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Cancel</button>
+              <button onClick={handleAddVaultSecret} disabled={!vaultForm.name || !vaultForm.value} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                <Shield className="w-4 h-4" /> Store Secret
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/packages/web/app/routes/skills.tsx
+++ b/packages/web/app/routes/skills.tsx
@@ -3,7 +3,8 @@ import { DashboardLayout } from '../components/DashboardLayout';
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@convex/_generated/api';
-import { Sparkles, Download, Trash2, Plus, Search, X, Check, Code, Globe, Calculator, FileText, Database, Mail, Wrench } from 'lucide-react';
+import { Sparkles, Download, Trash2, Plus, Search, Check, Code, Globe, Calculator, FileText, Database, Mail, Wrench } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 
 export const Route = createFileRoute('/skills')({ component: SkillsPage });
 
@@ -409,23 +410,24 @@ function SkillsPage() {
         )}
 
         {/* Code Preview Modal */}
-        {selectedSkill && (
-          <div key={selectedSkill.name} className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-            <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col">
-              <div className="flex justify-between items-center p-4 border-b border-border">
-                <h2 className="text-lg font-bold">{selectedSkill.displayName} — Source Code</h2>
-                <button onClick={() => setSelectedSkill(null)} className="text-muted-foreground hover:text-foreground"><X className="h-5 w-5" /></button>
-              </div>
-              <pre className="flex-1 overflow-auto p-4 text-xs font-mono bg-background text-foreground">{selectedSkill.code}</pre>
-              <div className="p-4 border-t border-border flex justify-end gap-2">
-                <button onClick={() => setSelectedSkill(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Close</button>
-                {!installedNames.has(selectedSkill.name) && (
-                  <button onClick={() => { handleInstall(selectedSkill); setSelectedSkill(null); }} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90">Install Skill</button>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
+        <Dialog open={!!selectedSkill} onOpenChange={(open) => { if (!open) setSelectedSkill(null); }}>
+          <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+            {selectedSkill && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>{selectedSkill.displayName} — Source Code</DialogTitle>
+                </DialogHeader>
+                <pre className="flex-1 overflow-auto p-4 text-xs font-mono bg-background text-foreground">{selectedSkill.code}</pre>
+                <DialogFooter>
+                  <button onClick={() => setSelectedSkill(null)} className="px-4 py-2 rounded-lg bg-muted text-muted-foreground text-sm">Close</button>
+                  {!installedNames.has(selectedSkill.name) && (
+                    <button onClick={() => { handleInstall(selectedSkill); setSelectedSkill(null); }} className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90">Install Skill</button>
+                  )}
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );

--- a/specs/active/SPEC-219-modal-outside-click.md
+++ b/specs/active/SPEC-219-modal-outside-click.md
@@ -1,0 +1,33 @@
+# SPEC-219: Modal Outside-Click Dismissal
+
+## Problem
+All 8 modals across 6 dashboard routes use hand-rolled `<div className="fixed inset-0 bg-black/60 z-50">` overlays that lack outside-click dismissal and escape-key support (Issue #219).
+
+## Solution
+Migrate all hand-rolled modal overlays to the shared Radix UI `Dialog` component from `packages/web/app/components/ui/dialog.tsx`, which provides:
+- Outside-click dismissal via `onOpenChange`
+- Escape key support
+- Focus trapping
+- Accessible ARIA attributes
+- Consistent overlay styling
+
+## Affected Routes (8 modals across 6 files)
+1. `agents.tsx` — 1 modal (AgentModal for create/edit)
+2. `connections.tsx` — 1 modal (Connect integration)
+3. `cron.tsx` — 2 modals (CronModal for create + edit)
+4. `projects.tsx` — 2 modals (Project create/edit form + ProjectDetailModal)
+5. `settings.tsx` — 2 modals (Add API Key + Add Vault Secret)
+6. `skills.tsx` — 1 modal (Code preview)
+
+## Migration Pattern
+For each modal:
+1. Add `import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog'`
+2. Replace `<div className="fixed inset-0 bg-black/60 z-50 ...">` with `<Dialog open={...} onOpenChange={...}><DialogContent>`
+3. Replace header div with `<DialogHeader><DialogTitle>`
+4. Replace footer div with `<DialogFooter>`
+5. Remove manual close buttons (DialogContent includes one)
+
+## Verification
+- Static analysis tests confirm no hand-rolled overlay patterns remain
+- All routes import from `components/ui/dialog`
+- `pnpm typecheck` passes


### PR DESCRIPTION
## Summary
- Migrated all 8 hand-rolled modal overlays across 6 dashboard routes (`agents`, `connections`, `cron`, `projects`, `settings`, `skills`) to use the shared Radix UI `Dialog` component from `components/ui/dialog`
- Fixes Issue #219: modals now dismiss on outside-click and escape key, with proper focus trapping and ARIA attributes
- Added static analysis regression tests (`modal-pattern.test.ts`) that enforce no hand-rolled overlay patterns and require Dialog imports

## Test plan
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm test` passes (1175 tests, all green)
- [x] 12/12 modal-pattern enforcement tests pass
- [x] Template sync verified across all 4 locations (Rule 6)
- [ ] Manual QA: open each modal, click outside to dismiss, press Escape to dismiss
- [ ] Manual QA: verify focus trapping works in each modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)