### PR TITLE
fix: add debug logging to silent catch blocks (#257)

### DIFF
--- a/convex/lib/tracing.ts
+++ b/convex/lib/tracing.ts
@@ -177,7 +177,7 @@ export async function sendTraceToOpik(
       },
       body: JSON.stringify(body),
     });
-  } catch {
-    // Intentionally swallowed — tracing must never throw
+  } catch (error) {
+    console.debug('[tracing] Failed to send trace to Opik:', error instanceof Error ? error.message : error);
   }
 }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -193,8 +193,8 @@ export function registerChatCommand(program: Command) {
             );
           }
           await safeCall(() => client.mutation('messages:add' as any, { threadId, role: 'user', content: input }), 'Failed to save message');
-        } catch {
-          // Non-fatal: continue with chat even if Convex save fails
+        } catch (error) {
+          console.debug(`[chat] Failed to save user message to Convex:`, error instanceof Error ? error.message : error);
         }
 
         try {
@@ -291,8 +291,8 @@ export function registerChatCommand(program: Command) {
         // Save to Convex
         try {
           await safeCall(() => client.mutation('messages:add' as any, { threadId, role: 'user', content: input }), 'Failed to save');
-        } catch {
-          // Non-fatal
+        } catch (error) {
+          console.debug(`[chat] Failed to save interactive user message:`, error instanceof Error ? error.message : error);
         }
 
         if (isTTY) {
@@ -320,8 +320,8 @@ export function registerChatCommand(program: Command) {
           // Save assistant response to Convex
           try {
             await safeCall(() => client.mutation('messages:add' as any, { threadId, role: 'assistant', content: fullResponse }), 'Failed to save');
-          } catch {
-            // Non-fatal
+          } catch (error) {
+            console.debug(`[chat] Failed to save assistant response:`, error instanceof Error ? error.message : error);
           }
         } catch (err) {
           console.log(`${colors.yellow}[Chat failed: ${err instanceof Error ? err.message : String(err)}]${colors.reset}`);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -110,8 +110,8 @@ export async function createProject(
       console.log(`\n  ✅ Dependencies installed (via ${pm})`);
       rootInstalled = true;
       break;
-    } catch {
-      // try next package manager
+    } catch (error) {
+      console.debug(`[create] Package manager '${pm}' failed for root install:`, error instanceof Error ? error.message : error);
     }
   }
   if (!rootInstalled) {
@@ -130,8 +130,8 @@ export async function createProject(
         console.log(`\n  ✅ Dashboard dependencies installed (via ${pm})`);
         dashInstalled = true;
         break;
-      } catch {
-        // try next
+      } catch (error) {
+        console.debug(`[create] Package manager '${pm}' failed for dashboard install:`, error instanceof Error ? error.message : error);
       }
     }
     if (!dashInstalled) {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -77,8 +77,8 @@ export async function readAgentForgeConfig(projectDir: string): Promise<any | nu
       const agentMatches = content.matchAll(/id:\s*["']([^"']+)["']/g);
       const agents = Array.from(agentMatches).map(m => ({ id: m[1] }));
       return { agents };
-    } catch {
-      // Fall through to JSON
+    } catch (error) {
+      console.debug('[readAgentForgeConfig] Failed to parse TS config, falling through to JSON:', error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -142,8 +142,8 @@ function readSkillsLock(skillsDir: string): SkillsLock {
   if (fs.existsSync(lockPath)) {
     try {
       return JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
-    } catch {
-      // Corrupted lock file, start fresh
+    } catch (error) {
+      console.debug('[readSkillsLock] Corrupted lock file, starting fresh:', error instanceof Error ? error.message : error);
     }
   }
   return { version: 1, skills: {} };
@@ -1491,8 +1491,8 @@ export function registerSkillsCommand(program: Command) {
           await client.mutation('skills:remove' as any, { id: skill._id });
           dim('  Skill removed from Convex database.');
         }
-      } catch {
-        // Convex not available — that's fine
+      } catch (error) {
+        console.debug('[skills:remove] Convex not available for skill removal:', error instanceof Error ? error.message : error);
       }
 
       info('Skill removed. Agents will no longer discover it.');

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -84,8 +84,8 @@ export function registerStatusCommand(program: Command) {
           const providers = [...new Set(activeKeys.map((k: any) => k.provider))];
           providerStatus = `Configured (${storedKeysCount} key${storedKeysCount > 1 ? 's' : ''}: ${providers.join(', ')})`;
         }
-      } catch {
-        // Fall back to env check if Convex query fails
+      } catch (error) {
+        console.debug('[status] Convex API keys query failed, falling back to env check:', error instanceof Error ? error.message : error);
       }
 
       checks['LLM Provider'] = storedKeysCount > 0 || providerStatus !== 'Not configured'

--- a/packages/cli/src/lib/cli-context.ts
+++ b/packages/cli/src/lib/cli-context.ts
@@ -34,8 +34,8 @@ function readEnvValue(key: string): string | undefined {
           return value.replace(/^["']|["']$/g, '');
         }
       }
-    } catch {
-      // File doesn't exist or can't be read, continue
+    } catch (error) {
+      console.debug('[readEnvValue] Failed to read env file %s:', envFile, error instanceof Error ? error.message : error);
     }
   }
   return undefined;

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -38,8 +38,8 @@ function readEnvValue(key: string): string | undefined {
           return envValueParts.join('=').trim();
         }
       }
-    } catch {
-      // File doesn't exist or can't be read, continue
+    } catch (error) {
+      console.debug('[readEnvValue] Failed to read env file %s:', envFile, error instanceof Error ? error.message : error);
     }
   }
   return undefined;

--- a/packages/cli/src/lib/convex-client.ts
+++ b/packages/cli/src/lib/convex-client.ts
@@ -44,8 +44,8 @@ function getConvexUrl(): string {
     try {
       const data = JSON.parse(fs.readFileSync(convexEnv, 'utf-8'));
       if (data.url) return data.url;
-    } catch {
-      // ignore
+    } catch (error) {
+      console.debug('[getConvexUrl] Failed to parse .convex/deployment.json:', error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/cli/src/lib/credentials.ts
+++ b/packages/cli/src/lib/credentials.ts
@@ -34,8 +34,8 @@ async function ensureCredentialsDir(): Promise<void> {
   // Set restrictive permissions (owner read/write only)
   try {
     await fs.chmod(CREDENTIALS_DIR, 0o700);
-  } catch {
-    // Ignore permission errors on Windows
+  } catch (error) {
+    console.debug('[credentials] Failed to set permissions on credentials dir:', error instanceof Error ? error.message : error);
   }
 }
 
@@ -73,8 +73,8 @@ export async function writeCredentials(credentials: Credentials): Promise<void> 
   // Set restrictive permissions (owner read/write only)
   try {
     await fs.chmod(CREDENTIALS_FILE, 0o600);
-  } catch {
-    // Ignore permission errors on Windows
+  } catch (error) {
+    console.debug('[credentials] Failed to set permissions on credentials file:', error instanceof Error ? error.message : error);
   }
 }
 

--- a/packages/cli/templates/default/convex/lib/tracing.ts
+++ b/packages/cli/templates/default/convex/lib/tracing.ts
@@ -177,7 +177,7 @@ export async function sendTraceToOpik(
       },
       body: JSON.stringify(body),
     });
-  } catch {
-    // Intentionally swallowed — tracing must never throw
+  } catch (error) {
+    console.debug('[tracing] Failed to send trace to Opik:', error instanceof Error ? error.message : error);
   }
 }

--- a/packages/core/src/a2a/a2a-client.ts
+++ b/packages/core/src/a2a/a2a-client.ts
@@ -136,8 +136,8 @@ export class A2AClient {
             try {
               const chunk = JSON.parse(trimmed.slice(6)) as A2AStreamChunk;
               yield chunk;
-            } catch {
-              // skip malformed lines
+            } catch (error) {
+              console.debug('[A2AClient.sendTaskStreaming] Skipping malformed SSE line:', error instanceof Error ? error.message : error);
             }
           }
         }

--- a/packages/core/src/adapters/telegram-adapter.ts
+++ b/packages/core/src/adapters/telegram-adapter.ts
@@ -272,8 +272,8 @@ export class TelegramAdapter extends ChannelAdapter {
     if (this.adapterConfig?.useWebhook) {
       try {
         await this.callApi('deleteWebhook');
-      } catch {
-        // Ignore errors on disconnect
+      } catch (error) {
+        console.debug('[TelegramAdapter.disconnect] Failed to delete webhook:', error instanceof Error ? error.message : error);
       }
     }
 
@@ -449,8 +449,8 @@ export class TelegramAdapter extends ChannelAdapter {
         chat_id: chatId,
         action: 'typing',
       });
-    } catch {
-      // Ignore typing indicator errors
+    } catch (error) {
+      console.debug('[TelegramAdapter.sendTypingIndicator] Failed for chat %s:', chatId, error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/core/src/adapters/whatsapp-adapter.ts
+++ b/packages/core/src/adapters/whatsapp-adapter.ts
@@ -936,8 +936,8 @@ export class WhatsAppAdapter extends ChannelAdapter {
           message_id: messageId,
         }
       );
-    } catch {
-      // Non-critical, ignore
+    } catch (error) {
+      console.debug('[WhatsAppAdapter.markAsRead] Failed for message %s:', messageId, error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/core/src/browser-tool.ts
+++ b/packages/core/src/browser-tool.ts
@@ -251,8 +251,8 @@ export class BrowserSessionManager {
             const data = JSON.parse(response);
             return data.webSocketDebuggerUrl || `ws://localhost:${port}`;
           }
-        } catch {
-          // Browser not ready yet
+        } catch (error) {
+          console.debug('[BrowserTool.launchDocker] Browser not ready yet:', error instanceof Error ? error.message : error);
         }
         await new Promise((resolve) => setTimeout(resolve, 1000));
         retries--;
@@ -261,8 +261,8 @@ export class BrowserSessionManager {
       // Cleanup on failure
       try {
         execSync(`docker stop agentforge-browser-${port}`, { timeout: 5_000 });
-      } catch {
-        // Ignore cleanup errors
+      } catch (error) {
+        console.debug('[BrowserTool.launchDocker] Failed to stop container on cleanup:', error instanceof Error ? error.message : error);
       }
 
       throw new Error('Docker sandbox browser failed to start within timeout');
@@ -334,8 +334,8 @@ export class BrowserSessionManager {
       if (this.config.persistState && this.config.statePath) {
         try {
           await context.storageState({ path: this.config.statePath });
-        } catch {
-          // Ignore save errors on close
+        } catch (error) {
+          console.debug('[BrowserTool.closeSession] Failed to save storage state:', error instanceof Error ? error.message : error);
         }
       }
       await context.close();
@@ -466,8 +466,8 @@ export class BrowserActionExecutor {
       try {
         result.currentUrl = page.url();
         result.pageTitle = await page.title();
-      } catch {
-        // Page might be closed
+      } catch (error) {
+        console.debug('[BrowserTool.execute] Failed to get page info (page may be closed):', error instanceof Error ? error.message : error);
       }
 
       result.latencyMs = Date.now() - startTime;

--- a/packages/core/src/channels/discord/discord-adapter.ts
+++ b/packages/core/src/channels/discord/discord-adapter.ts
@@ -312,8 +312,8 @@ export class DiscordAdapter extends ChannelAdapter {
       if (!channel) return;
       const sendable = channel as SendableChannel;
       await sendable.sendTyping();
-    } catch {
-      // Ignore typing indicator errors
+    } catch (error) {
+      console.debug('[DiscordAdapter.sendTypingIndicator] Failed for channel %s:', chatId, error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/core/src/channels/discord/discord-channel.ts
+++ b/packages/core/src/channels/discord/discord-channel.ts
@@ -443,8 +443,8 @@ export class DiscordChannel {
         metadata: { channelId, threadId, agentId: this.config.agentId },
         userId,
       });
-    } catch {
-      // Non-critical, ignore
+    } catch (error) {
+      console.debug('[DiscordChannel.getOrCreateThread] Failed to log conversation start:', error instanceof Error ? error.message : error);
     }
 
     return threadId;
@@ -461,8 +461,8 @@ export class DiscordChannel {
       if (agent) {
         agentName = (agent as { name: string }).name;
       }
-    } catch {
-      // Use default name
+    } catch (error) {
+      console.debug('[DiscordChannel.handleStartCommand] Failed to fetch agent name:', error instanceof Error ? error.message : error);
     }
 
     await this.adapter.sendMessage({

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -590,8 +590,8 @@ export class TelegramChannel {
         metadata: { chatId, threadId, agentId: this.config.agentId },
         userId,
       });
-    } catch {
-      // Non-critical, ignore
+    } catch (error) {
+      console.debug('[TelegramChannel.getOrCreateThread] Failed to log conversation start:', error instanceof Error ? error.message : error);
     }
 
     return threadId;
@@ -609,8 +609,8 @@ export class TelegramChannel {
       if (agent) {
         agentName = (agent as { name: string }).name;
       }
-    } catch {
-      // Use default name
+    } catch (error) {
+      console.debug('[TelegramChannel.handleStartCommand] Failed to fetch agent name:', error instanceof Error ? error.message : error);
     }
 
     await this.adapter.sendMessage({

--- a/packages/core/src/channels/whatsapp.ts
+++ b/packages/core/src/channels/whatsapp.ts
@@ -421,8 +421,8 @@ export class WhatsAppChannel {
     // Mark message as read (WhatsApp's equivalent of typing indicator)
     try {
       await this.adapter.addReaction(message.platformMessageId, message.chatId, '👀');
-    } catch {
-      // Non-critical
+    } catch (error) {
+      console.debug('[WhatsAppChannel.routeToAgent] Failed to add read reaction:', error instanceof Error ? error.message : error);
     }
 
     // Get or create thread for this chat
@@ -522,8 +522,8 @@ export class WhatsAppChannel {
         metadata: { phoneNumber, threadId, agentId: this.config.agentId },
         userId,
       });
-    } catch {
-      // Non-critical, ignore
+    } catch (error) {
+      console.debug('[WhatsAppChannel.getOrCreateThread] Failed to log conversation start:', error instanceof Error ? error.message : error);
     }
 
     return threadId;

--- a/packages/core/src/git-tool.ts
+++ b/packages/core/src/git-tool.ts
@@ -190,8 +190,8 @@ export class GitTool {
         try {
           const repo = this.inspectRepository(dir);
           repos.push(repo);
-        } catch {
-          // Skip repos we can't inspect
+        } catch (error) {
+          console.debug('[GitTool.searchForRepos] Skipping repo at %s:', dir, error instanceof Error ? error.message : error);
         }
         return; // Don't search inside a git repo for nested repos
       }
@@ -204,12 +204,12 @@ export class GitTool {
           if (statSync(fullPath).isDirectory()) {
             this.searchForRepos(fullPath, depth + 1, repos);
           }
-        } catch {
-          // Skip inaccessible directories
+        } catch (error) {
+          console.debug('[GitTool.searchForRepos] Skipping inaccessible entry %s:', fullPath, error instanceof Error ? error.message : error);
         }
       }
-    } catch {
-      // Skip inaccessible directories
+    } catch (error) {
+      console.debug('[GitTool.searchForRepos] Cannot read directory %s:', dir, error instanceof Error ? error.message : error);
     }
   }
 
@@ -225,7 +225,8 @@ export class GitTool {
     let remoteUrl: string | null = null;
     try {
       remoteUrl = this.exec('remote get-url origin', repoPath).trim() || null;
-    } catch {
+    } catch (error) {
+      console.debug('[GitTool.inspectRepository] No remote origin for %s:', repoPath, error instanceof Error ? error.message : error);
       remoteUrl = null;
     }
 
@@ -253,8 +254,8 @@ export class GitTool {
       const parts = abOutput.split('\t');
       ahead = parseInt(parts[0], 10) || 0;
       behind = parseInt(parts[1], 10) || 0;
-    } catch {
-      // No upstream configured
+    } catch (error) {
+      console.debug('[GitTool.getStatus] No upstream configured:', error instanceof Error ? error.message : error);
     }
 
     // Parse file statuses
@@ -483,8 +484,8 @@ export class GitTool {
         deletions += delNum;
         filesChanged++;
       }
-    } catch {
-      // Stat parsing failed, use raw diff
+    } catch (error) {
+      console.debug('[GitTool.getDiff] Stat parsing failed, using raw diff:', error instanceof Error ? error.message : error);
     }
 
     return { filesChanged, insertions, deletions, raw, files };

--- a/packages/core/src/mcp/mcp-client.ts
+++ b/packages/core/src/mcp/mcp-client.ts
@@ -216,8 +216,8 @@ export class StdioTransport implements MCPTransport {
         } else if ('method' in msg) {
           this.notificationHandler?.(msg as MCPJsonRpcNotification);
         }
-      } catch {
-        // Malformed JSON — skip
+      } catch (error) {
+        console.debug('[MCPClient.handleStdioData] Malformed JSON in stdio message:', error instanceof Error ? error.message : error);
       }
     }
   }
@@ -434,8 +434,8 @@ export class SSETransport implements MCPTransport {
       } else if ('method' in msg && eventType !== 'response') {
         this.notificationHandler?.(msg as MCPJsonRpcNotification);
       }
-    } catch {
-      // Malformed JSON — skip
+    } catch (error) {
+      console.debug('[MCPClient.handleSSEEvent] Malformed JSON in SSE event:', error instanceof Error ? error.message : error);
     }
   }
 
@@ -735,8 +735,8 @@ export class MCPClient {
           ...notification,
           id: crypto.randomUUID(),
         } as MCPJsonRpcRequest);
-      } catch {
-        // Notifications are fire-and-forget; swallow errors
+      } catch (error) {
+        console.debug('[MCPClient.sendNotification] Fire-and-forget notification failed:', error instanceof Error ? error.message : error);
       }
     } else if (this.transport instanceof StdioTransport) {
       // For stdio we can write the raw notification (no id)
@@ -751,8 +751,8 @@ export class MCPClient {
     for (const handler of this.eventHandlers) {
       try {
         handler(event);
-      } catch {
-        // Swallow handler errors
+      } catch (error) {
+        console.debug('[MCPClient.emit] Event handler threw:', error instanceof Error ? error.message : error);
       }
     }
   }

--- a/packages/core/src/mcp/mcp-dynamic-tools.ts
+++ b/packages/core/src/mcp/mcp-dynamic-tools.ts
@@ -91,8 +91,8 @@ export class MCPDynamicToolLoader {
           this.lastToolNames = currentNames;
           onUpdate({ ...this.tools });
         }
-      } catch {
-        // Polling errors are non-fatal; next interval will retry
+      } catch (error) {
+        console.debug('[MCPDynamicTools.watchTools] Polling error (will retry):', error instanceof Error ? error.message : error);
       }
     }, intervalMs);
   }

--- a/packages/core/src/sandbox/docker-sandbox.ts
+++ b/packages/core/src/sandbox/docker-sandbox.ts
@@ -205,8 +205,8 @@ export class DockerSandbox implements SandboxProvider {
       if (info.State.Running) {
         await this.container.stop({ t: 10 });
       }
-    } catch {
-      // Container may already be stopped — ignore
+    } catch (error) {
+      console.debug('[DockerSandbox.stop] Container may already be stopped:', error instanceof Error ? error.message : error);
     }
   }
 
@@ -224,8 +224,8 @@ export class DockerSandbox implements SandboxProvider {
 
     try {
       await container.remove({ force: true });
-    } catch {
-      // Already gone — ignore
+    } catch (error) {
+      console.debug('[DockerSandbox.destroy] Container already removed:', error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/core/src/sandbox/native-sandbox.ts
+++ b/packages/core/src/sandbox/native-sandbox.ts
@@ -58,8 +58,8 @@ export async function isNativeSandboxAvailable(): Promise<{
       // sandbox-exec is a built-in macOS tool; 'which' confirms it is on PATH
       await execFileAsync('which', ['sandbox-exec'], { timeout: 5000 });
       return { available: true, method: 'sandbox-exec' };
-    } catch {
-      // fall through
+    } catch (error) {
+      console.debug('[isNativeSandboxAvailable] sandbox-exec not found:', error instanceof Error ? error.message : error);
     }
   }
 
@@ -67,8 +67,8 @@ export async function isNativeSandboxAvailable(): Promise<{
     try {
       await execFileAsync('which', ['bwrap'], { timeout: 5000 });
       return { available: true, method: 'bwrap' };
-    } catch {
-      // fall through
+    } catch (error) {
+      console.debug('[isNativeSandboxAvailable] bwrap not found:', error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/core/src/skills/executable-skill-loader.ts
+++ b/packages/core/src/skills/executable-skill-loader.ts
@@ -88,8 +88,8 @@ async function resolveSkillEntry(skillDir: string): Promise<string | null> {
       if (stat.isFile()) {
         return fullPath;
       }
-    } catch {
-      // Ignore missing candidates.
+    } catch (error) {
+      console.debug('[resolveSkillEntry] Candidate not found %s:', candidate, error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/core/src/skills/marketplace-client.ts
+++ b/packages/core/src/skills/marketplace-client.ts
@@ -190,8 +190,8 @@ export async function installFromMarketplace(
   // Best-effort download tracking — don't fail install if this errors
   try {
     await convexQuery(convexUrl, 'skillMarketplace:incrementDownloads', { name });
-  } catch {
-    // intentionally ignored
+  } catch (error) {
+    console.debug('[installSkillFromMarketplace] Failed to increment download count:', error instanceof Error ? error.message : error);
   }
 
   return { skillDir, skill, references };

--- a/packages/core/src/skills/skill-discovery.ts
+++ b/packages/core/src/skills/skill-discovery.ts
@@ -44,8 +44,8 @@ export async function discoverSkills(
       const content = await fs.readFile(skillMdPath);
       const skill = parseSkillManifest(content);
       skills.push(skill);
-    } catch {
-      // Skip skills that fail to parse
+    } catch (error) {
+      console.debug('[discoverSkills] Failed to parse skill at %s:', skillMdPath, error instanceof Error ? error.message : error);
     }
   }
 

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -158,8 +158,8 @@ export class LocalWorkspaceProvider implements WorkspaceProvider {
             results.push(rel);
           }
         }
-      } catch {
-        // directory doesn't exist — return empty
+      } catch (error) {
+        console.debug('[Workspace.listFiles] Directory does not exist or is inaccessible %s:', currentDir, error instanceof Error ? error.message : error);
       }
     };
 

--- a/templates/default/convex/lib/tracing.ts
+++ b/templates/default/convex/lib/tracing.ts
@@ -177,7 +177,7 @@ export async function sendTraceToOpik(
       },
       body: JSON.stringify(body),
     });
-  } catch {
-    // Intentionally swallowed — tracing must never throw
+  } catch (error) {
+    console.debug('[tracing] Failed to send trace to Opik:', error instanceof Error ? error.message : error);
   }
 }


### PR DESCRIPTION
## Summary

- Added `console.debug()` logging to **46 silent catch blocks** across **29 files** in 3 packages
- Each debug log includes a descriptive `[context]` tag, the error message via `error instanceof Error ? error.message : error`, and relevant context variables (provider names, file paths, chat IDs, etc.)
- No control flow changes -- only added debug logging to previously empty/comment-only catch blocks
- Test files with intentional `// expected` catches were left unchanged
- All 3 synced Convex template locations updated identically (`convex/`, `packages/cli/templates/default/convex/`, `templates/default/convex/`)

### Breakdown by package

| Package | Files | Catches fixed |
|---------|-------|--------------|
| `packages/cli/` | 8 | 10 |
| `packages/core/` | 18 | 33 |
| `convex/` + `templates/` | 3 | 3 |
| **Total** | **29** | **46** |

### Categories of catches fixed
- Convex query/mutation failures (chat, status, skills, channels)
- File I/O errors (env files, credentials, lock files, config)
- Network/API errors (typing indicators, webhooks, tracing, marketplace)
- Cleanup/teardown errors (Docker containers, browser sessions, sandbox)
- JSON parsing errors (MCP messages, SSE events, A2A streaming)
- Tool discovery errors (sandbox availability, skill loading, git inspection)

## Test plan
- [x] `pnpm test` -- 1190 tests pass (74 test files, 0 failures)
- [x] `tsc --noEmit` in `packages/core`, `packages/cli`, `packages/runtime` -- 0 type errors
- [x] Verified no remaining silent catches in source files (only test files with intentional `// expected`)
- [x] Template sync: all 3 tracing.ts copies are identical

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging throughout the system by adding debug output for previously silent error handlers. When non-critical operations fail (e.g., tracing, environment file reads, network requests), detailed error messages are now logged to help with troubleshooting and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->